### PR TITLE
let Machine.add_states() take **kwargs

### DIFF
--- a/transitions/core.py
+++ b/transitions/core.py
@@ -584,7 +584,7 @@ class Machine(object):
         self.add_states(*args, **kwargs)
 
     def add_states(self, states, on_enter=None, on_exit=None,
-                   ignore_invalid_triggers=None):
+                   ignore_invalid_triggers=None, **kwargs):
         """ Add new state(s).
         Args:
             state (list, string, dict, or State): a list, a State instance, the
@@ -614,7 +614,7 @@ class Machine(object):
             if isinstance(state, string_types):
                 state = self._create_state(
                     state, on_enter=on_enter, on_exit=on_exit,
-                    ignore_invalid_triggers=ignore)
+                    ignore_invalid_triggers=ignore, **kwargs)
             elif isinstance(state, dict):
                 if 'ignore_invalid_triggers' not in state:
                     state['ignore_invalid_triggers'] = ignore

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -603,6 +603,8 @@ class Machine(object):
                 argument defined at the Machine level, and is in turn
                 overridden by any ignore_invalid_triggers explicitly
                 passed in an individual state's initialization arguments.
+
+            **kwargs additional keyword arguments used by state mixins.
         """
 
         ignore = ignore_invalid_triggers


### PR DESCRIPTION
This can be useful for state mixins, see also Issue #229.


—as discussed.

Tested with:

```
from transitions import Machine
from transitions.extensions.states import add_state_features, Timeout

import time


@add_state_features(Timeout)
class CustomMachine(Machine):
    pass


class Model(object):

    def timeout(self):
        print("Timeout!")
        self.to_A()

model = Model()

states = ['A',
          {'name': 'B', 'timeout': 0.3, 'on_timeout': 'timeout'},
          {'name': 'C', 'timeout': 0.9, 'on_timeout': model.timeout}]

m = CustomMachine(model, states=states, initial='A')
model.to_B()
time.sleep(1)  # >>> "Timeout!"
print model.state  # >>>  'A'


def hello():
    print("hello")


m.add_state("bob", timeout=0.5, on_timeout=hello)
model.to_bob()
time.sleep(1)

```