### PR TITLE
Add `Timeout.set_timeout()` method

### DIFF
--- a/transitions/extensions/states.py
+++ b/transitions/extensions/states.py
@@ -58,6 +58,10 @@ class Timeout(object):
             t.cancel()
         super(Timeout, self).exit(event_data)
 
+    def set_timeout(self, timeout, on_timeout):
+        self.timeout = timeout
+        self.on_timeout = on_timeout
+
 
 class Volatile(object):
 


### PR DESCRIPTION
In most cases, `transitions` allows to `machine.get_state(state).add_callback(function)`. However, with `Timeout`,
 - `add_callback` would have to take extra `*args`,
 - `Timeout.on_timeout` is not a list of callbacks but a single function so that `add_callback` would be misleading (the user is not *adding* anything but either setting a callback or replacing the one in place)

I would therefore propose to add a `set_timeout(self, timeout, on_timeout)` method for consistency.