### PR TITLE
Fix graph crash with partial conditions

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,6 +5,7 @@ except ImportError:
 
 from .utils import InheritedStuff
 from .utils import Stuff
+from functools import partial
 import sys
 from transitions import Machine, MachineError, State, EventData
 from transitions.core import listify, prep_ordered_arg
@@ -123,6 +124,24 @@ class TestTransitions(TestCase):
         s.machine.add_transition('advance', 'B', 'C', unless=['this_fails'])
         s.machine.add_transition('advance', 'C', 'D', unless=['this_fails',
                                                               'this_passes'])
+        s.advance()
+        self.assertEqual(s.state, 'B')
+        s.advance()
+        self.assertEqual(s.state, 'C')
+        s.advance()
+        self.assertEqual(s.state, 'C')
+
+    def test_conditions_with_partial(self):
+        def check(result):
+            return result
+
+        s = self.stuff
+        s.machine.add_transition('advance', 'A', 'B',
+                                 conditions=partial(check, True))
+        s.machine.add_transition('advance', 'B', 'C',
+                                 unless=[partial(check, False)])
+        s.machine.add_transition('advance', 'C', 'D',
+                                 unless=[partial(check, False), partial(check, True)])
         s.advance()
         self.assertEqual(s.state, 'B')
         s.advance()

--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -75,6 +75,31 @@ class TestDiagrams(TestCase):
         graph = m.get_graph(force_new=True, title=False)
         self.assertEqual("", graph.graph_attr['label'])
 
+    def test_anonymous_callable_conditions(self):
+        import functools
+        def check(result):
+            return result
+
+        class Check:
+            def __init__(self, result):
+                self.result = result
+            def __call__(self):
+                return self.result
+
+        m = self.machine_cls(states=self.states,
+                             transitions=self.transitions,
+                             initial='A',
+                             auto_transitions=False,
+                             show_conditions=True,
+                             title='a test')
+        m.add_state({'name': 'E'})
+        m.add_transition(trigger='fly', source='D', dest='E',
+                         conditions=Check(True))
+        m.add_transition(trigger='fly', source='D', dest='E',
+                         unless=functools.partial(check, False))
+        graph = m.get_graph()
+        self.assertIsNotNone(graph)
+
     def test_add_custom_state(self):
         m = self.machine_cls(states=self.states, transitions=self.transitions, initial='A', auto_transitions=False, title='a test')
         m.add_state('X')

--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -32,29 +32,36 @@ class TestRep(TestCase):
     def test_rep_function(self):
         def check():
             return True
+        self.assertTrue(check())
         self.assertEqual(rep(check), "check")
 
     def rest_rep_partial_no_args_no_kwargs(self):
         def check():
             return True
-        self.assertEqual(rep(partial(check)), "check()")
+        pcheck = partial(check)
+        self.assertTrue(pcheck())
+        self.assertEqual(rep(pcheck), "check()")
 
     def test_rep_partial_with_args(self):
         def check(result):
             return result
-        self.assertEqual(rep(partial(check, True)), "check(True)")
+        pcheck = partial(check, True)
+        self.assertTrue(pcheck())
+        self.assertEqual(rep(pcheck), "check(True)")
 
     def test_rep_partial_with_kwargs(self):
         def check(result=True):
             return result
-        self.assertEqual(rep(partial(check, result=True)),
-                         "check(result=True)")
+        pcheck = partial(check, result=True)
+        self.assertTrue(pcheck())
+        self.assertEqual(rep(pcheck), "check(result=True)")
 
     def test_rep_partial_with_args_and_kwargs(self):
         def check(result, doublecheck=True):
             return result == doublecheck
-        self.assertEqual(rep(partial(check, True, doublecheck=True)),
-                         "check(True, doublecheck=True)")
+        pcheck = partial(check, True, doublecheck=True)
+        self.assertTrue(pcheck())
+        self.assertEqual(rep(pcheck), "check(True, doublecheck=True)")
 
     def test_rep_callable_class(self):
         class Check(object):
@@ -67,7 +74,9 @@ class TestRep(TestCase):
             def __repr__(self):
                 return "%s(%r)" % (type(self).__name__, self.result)
 
-        self.assertEqual(rep(Check(True)), "Check(True)")
+        ccheck = Check(True)
+        self.assertTrue(ccheck())
+        self.assertEqual(rep(ccheck), "Check(True)")
 
 
 @skipIf(pgv is None, 'Graph diagram requires pygraphviz')

--- a/tests/test_graphing.py
+++ b/tests/test_graphing.py
@@ -6,9 +6,10 @@ except ImportError:
 from .utils import Stuff
 
 from transitions.extensions import MachineFactory
-from transitions.extensions.diagrams import Diagram
+from transitions.extensions.diagrams import Diagram, rep
 from transitions.extensions.nesting import NestedState
 from unittest import TestCase, skipIf
+from functools import partial
 import tempfile
 import os
 
@@ -21,6 +22,52 @@ except ImportError:  # pragma: no cover
 
 def edge_label_from_transition_label(label):
     return label.split(' | ')[0].split(' [')[0]  # if no condition, label is returned; returns first event only
+
+
+class TestRep(TestCase):
+
+    def test_rep_string(self):
+        self.assertEqual(rep("string"), "string")
+
+    def test_rep_function(self):
+        def check():
+            return True
+        self.assertEqual(rep(check), "check")
+
+    def rest_rep_partial_no_args_no_kwargs(self):
+        def check():
+            return True
+        self.assertEqual(rep(partial(check)), "check()")
+
+    def test_rep_partial_with_args(self):
+        def check(result):
+            return result
+        self.assertEqual(rep(partial(check, True)), "check(True)")
+
+    def test_rep_partial_with_kwargs(self):
+        def check(result=True):
+            return result
+        self.assertEqual(rep(partial(check, result=True)),
+                         "check(result=True)")
+
+    def test_rep_partial_with_args_and_kwargs(self):
+        def check(result, doublecheck=True):
+            return result == doublecheck
+        self.assertEqual(rep(partial(check, True, doublecheck=True)),
+                         "check(True, doublecheck=True)")
+
+    def test_rep_callable_class(self):
+        class Check(object):
+            def __init__(self, result):
+                self.result = result
+
+            def __call__(self):
+                return self.result
+
+            def __repr__(self):
+                return "%s(%r)" % (type(self).__name__, self.result)
+
+        self.assertEqual(rep(Check(True)), "Check(True)")
 
 
 @skipIf(pgv is None, 'Graph diagram requires pygraphviz')
@@ -74,31 +121,6 @@ class TestDiagrams(TestCase):
 
         graph = m.get_graph(force_new=True, title=False)
         self.assertEqual("", graph.graph_attr['label'])
-
-    def test_anonymous_callable_conditions(self):
-        import functools
-        def check(result):
-            return result
-
-        class Check:
-            def __init__(self, result):
-                self.result = result
-            def __call__(self):
-                return self.result
-
-        m = self.machine_cls(states=self.states,
-                             transitions=self.transitions,
-                             initial='A',
-                             auto_transitions=False,
-                             show_conditions=True,
-                             title='a test')
-        m.add_state({'name': 'E'})
-        m.add_transition(trigger='fly', source='D', dest='E',
-                         conditions=Check(True))
-        m.add_transition(trigger='fly', source='D', dest='E',
-                         unless=functools.partial(check, False))
-        graph = m.get_graph()
-        self.assertIsNotNone(graph)
 
     def test_add_custom_state(self):
         m = self.machine_cls(states=self.states, transitions=self.transitions, initial='A', auto_transitions=False, title='a test')

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -30,7 +30,7 @@ def rep(f):
             ", ".join(itertools.chain(
                 (str(_) for _ in f.args),
                 ("%s=%s" % (key, value)
-                 for key, value in iteritems(f.keywords)))))
+                 for key, value in iteritems(f.keywords if f.keywords else {})))))
     return str(f)
 
 

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -10,6 +10,7 @@ except ImportError:  # pragma: no cover
 
 import logging
 from functools import partial
+from six import string_types
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
@@ -117,7 +118,12 @@ class Graph(Diagram):
         return False
 
     def rep(self, f):
-        return f.__name__ if callable(f) else f
+        if isinstance(f, string_types):
+            return f
+        try:
+            return f.__name__
+        except AttributeError:
+            return str(f)
 
     def _transition_label(self, edge_label, tran):
         if self.machine.show_conditions and tran.conditions:

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -10,9 +10,28 @@ except ImportError:  # pragma: no cover
 
 import logging
 from functools import partial
-from six import string_types
+import itertools
+from six import string_types, iteritems
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
+
+
+def rep(f):
+    """Return a string representation for `f`."""
+    if isinstance(f, string_types):
+        return f
+    try:
+        return f.__name__
+    except AttributeError:
+        pass
+    if isinstance(f, partial):
+        return "%s(%s)" % (
+            f.func.__name__,
+            ", ".join(itertools.chain(
+                (str(_) for _ in f.args),
+                ("%s=%s" % (key, value)
+                 for key, value in iteritems(f.keywords)))))
+    return str(f)
 
 
 class Diagram(object):
@@ -117,20 +136,12 @@ class Graph(Diagram):
                 return True
         return False
 
-    def rep(self, f):
-        if isinstance(f, string_types):
-            return f
-        try:
-            return f.__name__
-        except AttributeError:
-            return str(f)
-
     def _transition_label(self, edge_label, tran):
         if self.machine.show_conditions and tran.conditions:
             return '{edge_label} [{conditions}]'.format(
                 edge_label=edge_label,
                 conditions=' & '.join(
-                    self.rep(c.func) if c.target else '!' + self.rep(c.func)
+                    rep(c.func) if c.target else '!' + rep(c.func)
                     for c in tran.conditions
                 ),
             )


### PR DESCRIPTION
Graph.rep() assumes that every callable has a `__name__` attribute.
However, callables like `functools.partial` and other classes with a
`__call__()` method have no `__name__`.  This patch modifies
`Graph.rep()` to first check whether the condition is a string and
return it, then try to return `f.__name__` (that is the current
behavior) and if that fails, then it calls `str()` on the argument.

`str()` should never fail and it is now the responsibility of the user
to return something meaningful from `__str__()`.