### PR TITLE
Fix double state callbacks.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -428,6 +428,22 @@ class TestTransitions(TestCase):
         self.assertTrue(m.before_state_change[0].called)
         self.assertTrue(m.after_state_change[0].called)
 
+    def test_state_callbacks(self):
+        class Model:
+            def on_enter_A(self): pass
+            def on_exit_A(self): pass
+            def on_enter_B(self): pass
+            def on_exit_B(self): pass
+        states = [
+                  State(name='A', on_enter='on_enter_A', on_exit='on_exit_A'),
+                  State(name='B', on_enter='on_enter_B', on_exit='on_exit_B')
+                  ]
+        machine = Machine(Model(), states=states)
+        self.assertEqual(len(states[0].on_enter), 1)
+        self.assertEqual(len(states[0].on_enter), 1)
+        self.assertEqual(len(states[1].on_exit), 1)
+        self.assertEqual(len(states[1].on_exit), 1)
+
     def test_pickle(self):
         import sys
         if sys.version_info < (3, 4):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -649,11 +649,13 @@ class Machine(object):
         #  Add enter/exit callbacks if there are existing bound methods
         enter_callback = 'on_enter_' + state.name
         if hasattr(model, enter_callback) and \
-                inspect.ismethod(getattr(model, enter_callback)):
+                inspect.ismethod(getattr(model, enter_callback)) and \
+                enter_callback not in state.on_enter:
             state.add_callback('enter', enter_callback)
         exit_callback = 'on_exit_' + state.name
         if hasattr(model, exit_callback) and \
-                inspect.ismethod(getattr(model, exit_callback)):
+                inspect.ismethod(getattr(model, exit_callback)) and \
+                exit_callback not in state.on_exit:
             state.add_callback('exit', exit_callback)
 
     def _add_trigger_to_model(self, trigger, model):


### PR DESCRIPTION
When on_(enter|exit) callback is explicitly specified during state creation
_and_ corresponding model method exists _and_ its name equals default state
callback name (i.e. 'on_exit_STATENAME' or 'on_enter_STATENAME') then
callback is added twice. This patch fixes that case.