### PR TITLE
Add Machine.add_transitions to core

### DIFF
--- a/transitions/core.py
+++ b/transitions/core.py
@@ -440,12 +440,7 @@ class Machine(object):
             self.initial = initial
 
         if transitions is not None:
-            transitions = listify(transitions)
-            for t in transitions:
-                if isinstance(t, list):
-                    self.add_transition(*t)
-                else:
-                    self.add_transition(**t)
+            self.add_transitions(transitions)
 
         if ordered_transitions:
             self.add_ordered_transitions()
@@ -701,6 +696,19 @@ class Machine(object):
             t = self._create_transition(s, d, conditions, unless, before,
                                         after, prepare, **kwargs)
             self.events[trigger].add_transition(t)
+
+    def add_transitions(self, transitions):
+        """ Add several transitions.
+
+        Args:
+            transitions (list): A list of transitions.
+
+        """
+        for t in listify(transitions):
+            if isinstance(t, list):
+                self.add_transition(*t)
+            else:
+                self.add_transition(**t)
 
     def add_ordered_transitions(self, states=None, trigger='next_state',
                                 loop=True, loop_includes_initial=True,


### PR DESCRIPTION
[Note the plural]

This is consistent with `add_state` (singular) and `add_states` (plural)
and also with the ability of `__init__` to take a list of transitions.

I simply extracted the routine in `__init__` to its own method.

---

As a side note, I would prefer that `add_states` and
`add_transitions` take star-args so that the user does not need
the `[]` (easily forgotten)...

Something like:

```
...
    add_states(self, *states):
        for s in states:
            self.add_state(s)

    add_transitions(self, *transitions):
        for t in transitions:
            self.add_transition(t)
...

machine.add_states(STATE1, STATE2)   # That seems more natural to me.
machine.add_states(*STATES)

```

I am not holding my breath, though, because that would be a
breaking change.