### PR TITLE
Allow the process to exit when in a timeout state.

### DIFF
--- a/transitions/extensions/states.py
+++ b/transitions/extensions/states.py
@@ -54,6 +54,7 @@ class Timeout(object):
     def enter(self, event_data):
         if self.timeout > 0:
             t = Timer(self.timeout, self._process_timeout, args=(event_data,))
+            t.setDaemon(True)
             t.start()
             self.runner[id(event_data.model)] = t
         super(Timeout, self).enter(event_data)


### PR DESCRIPTION
This way, a program currently in a timeout state can exit immediately without having to determine if it needs to change to a non-timeout state. A simple proof of concept:

```python
#!/usr/bin/python
import sys 
import logging

from transitions import Machine
from transitions.extensions.states import add_state_features, Timeout

@add_state_features(Timeout)
class TimeoutMachine(Machine):
    pass

class TestMachine(object):
    states = [{'name': 'init'},
              {'name': 'one', 'timeout': 5, 'on_timeout': 'to_two'},
              {'name': 'two', 'timeout': 5, 'on_timeout': 'to_one'},]

    def __init__(self):
        self.fsm = fsm = TimeoutMachine(model=self, states=self.states, initial='init')

def main():
    logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
    lgr = logging.getLogger()

    m = TestMachine()
    m.to_one()
    print "Done, should now exit"

if __name__ == '__main__':
    main()
```

The fix is fairly simple, just call `setDaemon(True)` on the timeout thread. However, I'm not a threading wizard, and don't know if this breaks anything.

I've attached a simple pull request, and verified that it passes existing unit tests. I hope this helps!