### PR TITLE
Get transitions

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -863,6 +863,16 @@ class TestTransitions(TestCase):
         model.blocker = True
         self.assertTrue(model.next_state())
 
+    def test_get_transitions(self):
+        self.stuff.machine.add_transition('go', ['A', 'B', 'C'], 'D')
+        self.stuff.machine.add_transition('walk', 'A', 'B')
+        go_transitions = list(self.stuff.machine.get_transitions("go"))
+        walk_transitions = list(self.stuff.machine.get_transitions("walk"))
+        self.assertEqual(len(go_transitions), 3)
+        self.assertEqual(set(t.source for t in go_transitions), {'A', 'B', 'C'})
+        self.assertEqual(set(t.dest for t in go_transitions), {'D'})
+        self.assertEqual(len(walk_transitions), 1)
+
     def test_remove_transition(self):
         self.stuff.machine.add_transition('go', ['A', 'B', 'C'], 'D')
         self.stuff.machine.add_transition('walk', 'A', 'B')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -864,14 +864,17 @@ class TestTransitions(TestCase):
         self.assertTrue(model.next_state())
 
     def test_get_transitions(self):
-        self.stuff.machine.add_transition('go', ['A', 'B', 'C'], 'D')
-        self.stuff.machine.add_transition('walk', 'A', 'B')
-        go_transitions = list(self.stuff.machine.get_transitions("go"))
-        walk_transitions = list(self.stuff.machine.get_transitions("walk"))
-        self.assertEqual(len(go_transitions), 3)
-        self.assertEqual(set(t.source for t in go_transitions), {'A', 'B', 'C'})
-        self.assertEqual(set(t.dest for t in go_transitions), {'D'})
-        self.assertEqual(len(walk_transitions), 1)
+        states = ['A', 'B', 'C', 'D']
+        m = Machine('self', states, initial='a', auto_transitions=False)
+        m.add_transition('go', ['A', 'B', 'C'], 'D')
+        m.add_transition('run', 'A', 'D')
+        self.assertEqual(
+            {(t.source, t.dest) for t in m.get_transitions('go')},
+            {('A', 'D'), ('B', 'D'), ('C', 'D')})
+        self.assertEqual(
+            [(t.source, t.dest)
+             for t in m.get_transitions(source='A', dest='D')],
+            [('A', 'D'), ('A', 'D')])
 
     def test_remove_transition(self):
         self.stuff.machine.add_transition('go', ['A', 'B', 'C'], 'D')

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -931,7 +931,7 @@ class Machine(object):
     def remove_transition(self, trigger, source="*", dest="*"):
         """ Removes a transition from the Machine and all models.
         Args:
-            trigger (string): Trigger name of the transition
+            trigger (string): Trigger name of the transition.
             source (string): Limits removal to transitions from a certain state.
             dest (string): Limits removal to transitions to a certain state.
         """

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -928,20 +928,26 @@ class Machine(object):
                                 prepare=prepare[-1],
                                 **kwargs)
 
-    def get_transitions(self, trigger, source="*", dest="*"):
+    def get_transitions(self, trigger="", source="*", dest="*"):
         """ Return the transitions from the Machine.
         Args:
             trigger (string): Trigger name of the transition.
             source (string): Limits removal to transitions from a certain state.
             dest (string): Limits removal to transitions to a certain state.
         """
-        transitions = itertools.chain.from_iterable(
-            self.events[trigger].transitions.values())
-        return (transition
+        if trigger:
+            events = (self.events[trigger], )
+        else:
+            events = self.events.values()
+        transitions = []
+        for event in events:
+            transitions.extend(
+                itertools.chain.from_iterable(event.transitions.values()))
+        return [transition
                 for transition in transitions
                 if (transition.source, transition.dest) == (
                     source if source != "*" else transition.source,
-                    dest if dest != "*" else transition.dest))
+                    dest if dest != "*" else transition.dest)]
 
     def remove_transition(self, trigger, source="*", dest="*"):
         """ Removes a transition from the Machine and all models.

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -928,6 +928,21 @@ class Machine(object):
                                 prepare=prepare[-1],
                                 **kwargs)
 
+    def get_transitions(self, trigger, source="*", dest="*"):
+        """ Return the transitions from the Machine.
+        Args:
+            trigger (string): Trigger name of the transition.
+            source (string): Limits removal to transitions from a certain state.
+            dest (string): Limits removal to transitions to a certain state.
+        """
+        transitions = itertools.chain.from_iterable(
+            self.events[trigger].transitions.values())
+        return (transition
+                for transition in transitions
+                if (transition.source, transition.dest) == (
+                    source if source != "*" else transition.source,
+                    dest if dest != "*" else transition.dest))
+
     def remove_transition(self, trigger, source="*", dest="*"):
         """ Removes a transition from the Machine and all models.
         Args:


### PR DESCRIPTION
Hi,

This is a new `get_transitions(trigger, source="*" dest="*")`
method on `Machine`. It returns the generator of
corresponding transitions.

My use case for it is that I declare a prototype FSM in a base
class and sometimes need to add before/after callbacks
afterwards.

Moreover, I think that since `Machine` already has a few
`add/get` pairs, a `get_transitions()` method is not surprising
in the API.

Best,
Mathias