### PR TITLE
Fix missing () in extensions/states

### DIFF
--- a/transitions/extensions/states.py
+++ b/transitions/extensions/states.py
@@ -103,7 +103,7 @@ class Timeout(State):
     def exit(self, event_data):
         """ Extends `transitions.core.State.exit` by canceling a timer for the current model. """
         timer = self.runner.get(id(event_data.model), None)
-        if timer is not None and timer.is_alive:
+        if timer is not None and timer.is_alive():
             timer.cancel()
         super(Timeout, self).exit(event_data)
 


### PR DESCRIPTION
[Thread.is_alive()](https://docs.python.org/3/library/threading.html#threading.Thread.is_alive) is a function and the call operator `()` is missing line 106 of `transitions/extensions/states.py`.

This is obviously a bug and here is the fix!