### PR TITLE
Fix installation on Python 3 with non-UTF-8 locale

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
+import codecs
 import sys
 from setuptools import setup, find_packages
 
 with open('transitions/version.py') as f:
     exec(f.read())
 
-with open("README.md") as f:
+with codecs.open('README.md', 'r', 'utf-8') as f:
     # cut the badges from the description and also the TOC which is currently not working on PyPi
     long_description = ''.join(f.readlines()[49:])
 


### PR DESCRIPTION
When `setup.py` is executed, it reads `README.md` using the systems default encoding. However, `README.md` contains UTF-8 encoded characters.

If installing transitions under Python 3 on a system with a non-UTF-8 locale, like `C`, Python crashes with an `UnicodeDecodeError` because it fails to decode `README.md` as ASCII, which is the default encoding in the C locale.

To reproduce:

```
virtualenv -p /usr/bin/python3 venv
. venv/bin/activate
LANG=C LC_ALL=C pip install transitions
```

This fix decodes `README.md` explicitly as UTF-8 in a way that works on both Python 2 and 3.