### PR TITLE
Ensure enter callback is called in the Error State extension

### DIFF
--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -51,6 +51,24 @@ class TestTransitions(TestCase):
         with self.assertRaises(MachineError):
             m.fail()
 
+    def test_error_callback(self):
+        @add_state_features(Error)
+        class CustomMachine(Machine):
+            pass
+
+        mock_callback = MagicMock()
+
+        states = ['A', {"name": "B", "on_enter": mock_callback}, 'C']
+        transitions = [
+            ["to_B", "A", "B"],
+            ["to_C", "B", "C"],
+        ]
+        m = CustomMachine(states=states, transitions=transitions, auto_transitions=False, initial='A')
+        m.to_B()
+        self.assertEqual(m.state, "B")
+        self.assertTrue(mock_callback.called)
+
+
     def test_timeout(self):
         mock = MagicMock()
 

--- a/transitions/extensions/states.py
+++ b/transitions/extensions/states.py
@@ -59,6 +59,7 @@ class Error(Tags):
         """
         if not event_data.machine.get_triggers(self.name) and not self.is_accepted:
             raise MachineError("Error state '{0}' reached!".format(self.name))
+        super(Error, self).enter(event_data)
 
 
 class Timeout(State):


### PR DESCRIPTION
Only call super().enter() to ensure the enter callback is called when there is no exception 

should correct #316 , at least on Error alone (still problem with Error and Timeout needed)