### PR TITLE
add space after machine name in log messages

### DIFF
--- a/transitions/core.py
+++ b/transitions/core.py
@@ -115,17 +115,17 @@ class State(object):
 
     def enter(self, event_data):
         """ Triggered when a state is entered. """
-        _LOGGER.debug("%sEntering state %s. Processing callbacks...", event_data.machine.name, self.name)
+        _LOGGER.debug("%s Entering state %s. Processing callbacks...", event_data.machine.name, self.name)
         for handle in self.on_enter:
             event_data.machine.callback(handle, event_data)
-        _LOGGER.info("%sEntered state %s", event_data.machine.name, self.name)
+        _LOGGER.info("%s Entered state %s", event_data.machine.name, self.name)
 
     def exit(self, event_data):
         """ Triggered when a state is exited. """
-        _LOGGER.debug("%sExiting state %s. Processing callbacks...", event_data.machine.name, self.name)
+        _LOGGER.debug("%s Exiting state %s. Processing callbacks...", event_data.machine.name, self.name)
         for handle in self.on_exit:
             event_data.machine.callback(handle, event_data)
-        _LOGGER.info("%sExited state %s", event_data.machine.name, self.name)
+        _LOGGER.info("%s Exited state %s", event_data.machine.name, self.name)
 
     def add_callback(self, trigger, func):
         """ Add a new enter or exit callback.
@@ -242,7 +242,7 @@ class Transition(object):
         Returns: boolean indicating whether or not the transition was
             successfully executed (True if successful, False if not).
         """
-        _LOGGER.debug("%sInitiating transition from state %s to state %s...",
+        _LOGGER.debug("%s Initiating transition from state %s to state %s...",
                       event_data.machine.name, self.source, self.dest)
         machine = event_data.machine
 
@@ -252,19 +252,19 @@ class Transition(object):
 
         for cond in self.conditions:
             if not cond.check(event_data):
-                _LOGGER.debug("%sTransition condition failed: %s() does not return %s. Transition halted.",
+                _LOGGER.debug("%s Transition condition failed: %s() does not return %s. Transition halted.",
                               event_data.machine.name, cond.func, cond.target)
                 return False
         for func in itertools.chain(machine.before_state_change, self.before):
             machine.callback(func, event_data)
-            _LOGGER.debug("%sExecuted callback '%s' before transition.", event_data.machine.name, func)
+            _LOGGER.debug("%s Executed callback '%s' before transition.", event_data.machine.name, func)
 
         if self.dest:  # if self.dest is None this is an internal transition with no actual state change
             self._change_state(event_data)
 
         for func in itertools.chain(self.after, machine.after_state_change):
             machine.callback(func, event_data)
-            _LOGGER.debug("%sExecuted callback '%s' after transition.", event_data.machine.name, func)
+            _LOGGER.debug("%s Executed callback '%s' after transition.", event_data.machine.name, func)
         return True
 
     def _change_state(self, event_data):
@@ -779,7 +779,7 @@ class Machine(object):
 
     def _checked_assignment(self, model, name, func):
         if hasattr(model, name):
-            _LOGGER.warning("%sModel already contains an attribute '%s'. Skip binding.", self.name, name)
+            _LOGGER.warning("%s Model already contains an attribute '%s'. Skip binding.", self.name, name)
         else:
             setattr(model, name, func)
 

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -294,7 +294,7 @@ class HierarchicalMachine(Machine):
             mod = self if mod == 'self' else mod
             # TODO: Remove 'mod != self' in 0.7.0
             if hasattr(mod, 'to') and mod != self:
-                _LOGGER.warning("%sModel already has a 'to'-method. It will NOT "
+                _LOGGER.warning("%s Model already has a 'to'-method. It will NOT "
                                 "be overwritten by NestedMachine", self.name)
             else:
                 to_func = partial(self.to_state, mod)

--- a/transitions/extensions/states.py
+++ b/transitions/extensions/states.py
@@ -109,10 +109,10 @@ class Timeout(State):
         super(Timeout, self).exit(event_data)
 
     def _process_timeout(self, event_data):
-        _LOGGER.debug("%sTimeout state %s. Processing callbacks...", event_data.machine.name, self.name)
+        _LOGGER.debug("%s Timeout state %s. Processing callbacks...", event_data.machine.name, self.name)
         for callback in self.on_timeout:
             event_data.machine.callback(callback, event_data)
-        _LOGGER.info("%sTimeout state %s processed.", event_data.machine.name, self.name)
+        _LOGGER.info("%s Timeout state %s processed.", event_data.machine.name, self.name)
 
     @property
     def on_timeout(self):


### PR DESCRIPTION
makes the logs more readable