### PR TITLE
Run tests on Python 3.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python:
   - "3.6"
@@ -11,7 +12,6 @@ install:
 script:  nosetests --with-coverage --with-doctest
 after_success:
   - coveralls --config_file .coveragerc
-sudo: false
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 dist: xenial
 language: python
 python:
-  - "3.6"
-  - "3.5"
   - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 install:
   - pip install python-coveralls coverage
   - pip install -r requirements.txt


### PR DESCRIPTION
Since Python 3.7 was taken out of the test matrix in 9dedc70517a7f30e51e2f5b86c5a26835a03d759, Travis has shipped support for Ubuntu 16.04 and with that support for running tests on Python 3.7.