### PR TITLE
Remove unused import in test case

### DIFF
--- a/tests/test_add_remove.py
+++ b/tests/test_add_remove.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     pass
 
-from transitions import Machine, MachineError
+from transitions import Machine
 from unittest import TestCase
 
 import gc


### PR DESCRIPTION
`MachineError` not used in the test. This PR removes its class from the import statement