### PR TITLE
Add python 3.7 compatibility to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     **extra_setuptools_args
 )


### PR DESCRIPTION
Run tests on python 3.7 added in this PR https://github.com/pytransitions/transitions/pull/337. 
