### PR TITLE
Add support for enums

### DIFF
--- a/transitions/core.py
+++ b/transitions/core.py
@@ -17,6 +17,7 @@ import inspect
 import itertools
 import logging
 import warnings
+import enum
 
 from collections import OrderedDict, defaultdict, deque
 from functools import partial
@@ -39,7 +40,8 @@ def listify(obj):
     """
     if obj is None:
         return []
-    return obj if isinstance(obj, (list, tuple)) else [obj]
+
+    return obj if isinstance(obj, (list, tuple, enum.EnumMeta)) else [obj]
 
 
 def _get_trigger(model, machine, trigger_name, *args, **kwargs):
@@ -94,8 +96,7 @@ class State(object):
     # Dynamic methods for states must always start with `on_`!
     dynamic_methods = ['on_enter', 'on_exit']
 
-    def __init__(self, name, on_enter=None, on_exit=None,
-                 ignore_invalid_triggers=False):
+    def __init__(self, name, on_enter=None, on_exit=None, ignore_invalid_triggers=False):
         """
         Args:
             name (string): The name of the state
@@ -109,10 +110,21 @@ class State(object):
                 unhandled/invalid triggers should raise an exception
 
         """
-        self.name = name
+        self._name = name
         self.ignore_invalid_triggers = ignore_invalid_triggers
         self.on_enter = listify(on_enter) if on_enter else []
         self.on_exit = listify(on_exit) if on_exit else []
+
+    @property
+    def name(self):
+        if isinstance(self._name, enum.Enum):
+            return self._name.name
+        else:
+            return self._name
+
+    @property
+    def value(self):
+        return self._name
 
     def enter(self, event_data):
         """ Triggered when a state is entered. """
@@ -334,7 +346,11 @@ class EventData(object):
         Attributes:
             model (object): The updated model which gets the updated state assigned to its attribute `state`.
         """
-        self.state = self.machine.get_state(model.state)
+        state_name = model.state
+        if isinstance(model.state, enum.Enum):
+            state_name = model.state.name
+
+        self.state = self.machine.get_state(state_name)
 
     def __repr__(self):
         return "<%s('%s', %s)@%s>" % (type(self).__name__, self.state,
@@ -387,7 +403,12 @@ class Event(object):
         """ Internal trigger function called by the ``Machine`` instance. This should not
         be called directly but via the public method ``Machine.trigger``.
         """
-        state = self.machine.get_state(model.state)
+        if isinstance(model.state, enum.Enum):
+            state_name = model.state.name
+        else:
+            state_name = model.state
+
+        state = self.machine.get_state(state_name)
         if state.name not in self.transitions:
             msg = "%sCan't trigger event %s from state %s!" % (self.machine.name, self.name,
                                                                state.name)
@@ -710,12 +731,20 @@ class Machine(object):
         return model.state == state
 
     def set_state(self, state, model=None):
-        """ Set the current state. """
+        """
+            Set the current state.
+        Args:
+            state (str or Enum): value of setted state
+        """
         if isinstance(state, string_types):
             state = self.get_state(state)
+        elif isinstance(state, enum.Enum):
+            state = self.get_state(state.name)
+
         models = self.models if model is None else listify(model)
+
         for mod in models:
-            mod.state = state.name
+            mod.state = state.value
 
     def add_state(self, *args, **kwargs):
         """ Alias for add_states. """
@@ -750,8 +779,9 @@ class Machine(object):
             ignore = self.ignore_invalid_triggers
 
         states = listify(states)
+
         for state in states:
-            if isinstance(state, string_types):
+            if isinstance(state, string_types) or isinstance(state, enum.Enum):
                 state = self._create_state(
                     state, on_enter=on_enter, on_exit=on_exit,
                     ignore_invalid_triggers=ignore, **kwargs)
@@ -768,7 +798,7 @@ class Machine(object):
                 self.add_transition('to_%s' % state, self.wildcard_all, state)
 
     def _add_model_to_state(self, state, model):
-        self._checked_assignment(model, 'is_%s' % state.name, partial(self.is_state, state.name, model))
+        self._checked_assignment(model, 'is_%s' % state.name, partial(self.is_state, state.value, model))
 
         # Add dynamic method callbacks (enter/exit) if there are existing bound methods in the model
         # except if they are already mentioned in 'on_enter/exit' of the defined state
@@ -836,11 +866,11 @@ class Machine(object):
         if isinstance(source, string_types):
             source = list(self.states.keys()) if source == self.wildcard_all else [source]
         else:
-            source = [s.name if self._has_state(s) else s for s in listify(source)]
+            source = [s.name if self._has_state(s) or isinstance(s, enum.Enum) else s for s in listify(source)]
 
         for state in source:
             _dest = state if dest == self.wildcard_same else dest
-            if _dest and self._has_state(_dest):
+            if _dest and self._has_state(_dest) or isinstance(_dest, enum.Enum):
                 _dest = _dest.name
             _trans = self._create_transition(state, _dest, conditions, unless, before,
                                              after, prepare, **kwargs)


### PR DESCRIPTION
Hi, it's a simple draft attempt to add support for enums (https://github.com/pytransitions/transitions/issues/334).
The main idea is to pass states to `machine` as we can do it with strings to `State` class and work with it.

I added some tests to illustrate the api

Example:
``` python
class States(enum.Enum):
  RED = 1
  YELLOW = 2
  GREEN = 3

m = Machine(states=States, initial=States.YELLOW)

m.states
=> OrderedDict([('RED', <State('RED')@4370833592>), ('YELLOW', <State('YELLOW')@4370472240>), ('GREEN', <State('GREEN')@4371112008>)])

m.to_RED()

m.is_RED() # => True
m.state => <States.RED: 1>

m.add_transition('switch_to_yellow', self.States.RED, self.States.YELLOW)
```

But now in the code base, we have many conditions `isinstance(state, string_types, )` or `isinstance(state, State)`. For support enums i added check `isinstance(state, enum.Enum)` and it not looking good and we should drop support for python < 3.4. 

Any suggestions how enums should work are welcome :)

@aleneum what do you think about this implementation?