### PR TITLE
Fix setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,13 @@ with open('transitions/version.py') as f:
     exec(f.read())
 
 with codecs.open('README.md', 'r', 'utf-8') as f:
+    import re
     # cut the badges from the description and also the TOC which is currently not working on PyPi
-    long_description = ''.join(f.readlines()[51:])
-    assert long_description[:3] == '## '  # Description should start with a headline (## Quickstart)
+    regex = r"([\s\S]*)## Quickstart"
+    readme = f.read()
+
+    long_description = re.sub(regex, "## Quickstart", readme, 1)
+    assert long_description[:13] == '## Quickstart'  # Description should start with a headline (## Quickstart)
 
 if len(set(('test', 'easy_install')).intersection(sys.argv)) > 0:
     import setuptools


### PR DESCRIPTION
Problem
---
assert in setup.py fails with error
```
Traceback (most recent call last):
  File "setup.py", line 11, in <module>
    assert long_description[:3] == '## '  # Description should start with a headline (## Quickstart)
AssertionError
```

```
-> assert long_description[:3] == '## '  # Description should start with a headline (## Quickstart)
(Pdb) long_description[:3]
'\n##'
```
Solution
---
Use regexp to remove text before `## Quickstart` section
