### PR TITLE
Don't mask away KeyError when executing a transition

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -774,6 +774,13 @@ class TestTransitions(TestCase):
         m = Machine(model=model)
         self.assertEqual(model.trigger(5), 5)
 
+        def raise_key_error():
+            raise KeyError
+
+        self.stuff.machine.add_transition('do_raises_keyerror', '*', 'C', before=raise_key_error)
+        with self.assertRaises(KeyError):
+            self.stuff.trigger('do_raises_keyerror')
+
     def test_get_triggers(self):
         states = ['A', 'B', 'C']
         transitions = [['a2b', 'A', 'B'],

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -62,10 +62,10 @@ def _get_trigger(model, machine, trigger_name, *args, **kwargs):
         bool: True if a transitions has been conducted or the trigger event has been queued.
     """
     try:
-        return machine.events[trigger_name].trigger(model, *args, **kwargs)
+        event = machine.events[trigger_name]
     except KeyError:
-        pass
-    raise AttributeError("Do not know event named '%s'." % trigger_name)
+        raise AttributeError("Do not know event named '%s'." % trigger_name)
+    return event.trigger(model, *args, **kwargs)
 
 
 def _prep_ordered_arg(desired_length, arguments=None):


### PR DESCRIPTION
This should fix issue #377.