### PR TITLE
Fix transitions for enums with str behavior (Django3)

### DIFF
--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -47,6 +47,19 @@ class TestEnumsAsStates(TestCase):
         assert m.is_YELLOW() is False
         assert m.is_GREEN() is True
 
+    def test_if_enum_has_string_behavior(self):
+        class States(str, enum.Enum):
+            __metaclass__ = enum.EnumMeta
+
+            RED = 'red'
+            YELLOW = 'yellow'
+
+        m = self.machine_cls(states=States, auto_transitions=False, initial=States.RED)
+        m.add_transition('switch_to_yellow', States.RED, States.YELLOW)
+
+        m.switch_to_yellow()
+        assert m.is_YELLOW() is True
+
     def test_property_initial(self):
         transitions = [
             {'trigger': 'switch_to_yellow', 'source': self.States.RED, 'dest': self.States.YELLOW},

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -858,8 +858,8 @@ class Machine(object):
             for model in self.models:
                 self._add_trigger_to_model(trigger, model)
 
-        if isinstance(source, string_types):
-            source = list(self.states.keys()) if source == self.wildcard_all else [source]
+        if source == self.wildcard_all:
+            source = list(self.states.keys())
         else:
             source = [s.name if self._has_state(s) or isinstance(s, Enum) else s for s in listify(source)]
 


### PR DESCRIPTION
Django3 introduced enums (TextChoices), but this enums has str behavior
see https://github.com/django/django/blob/master/django/db/models/enums.py#L77

isinstance(source, string_types) returns True

To avoid this behavior, we need to remove the check on str class.