### PR TITLE
Add support for dynamic model state attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,8 +934,8 @@ lump.state
 lump.shipping_state
 >>> 'delivered'
 
-matter_machine = Machine(lump, model_field='state', **kwargs)
-shipment_machine = Machine(lump, model_field='shipping_state', **kwargs)
+matter_machine = Machine(lump, model_attribute='state', **kwargs)
+shipment_machine = Machine(lump, model_attribute='shipping_state', **kwargs)
 ```
 
 ### Logging

--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ machine = Machine(lump, states=['A', 'B', 'C'])
 
 Now, any time `lump` transitions to state `A`, the `on_enter_A()` method defined in the `Matter` class will fire.
 
+#### <a name="checking-state"></a>Checking state
+
 You can always check the current state of the model by either:
 
 - inspecting the `.state` attribute, or
@@ -334,6 +336,15 @@ lump.is_gas()
 lump.is_solid()
 >>> True
 machine.get_state(lump.state).name
+>>> 'solid'
+```
+
+If you'd like you track it using a different attribute, you could do that using the `model_attribute` argument while initializing the `Machine`.
+
+```python
+lump = Matter()
+machine = Machine(lump, states=['solid', 'liquid', 'gas'],  model='matter_state', initial='solid')
+lump.matter_state
 >>> 'solid'
 ```
 
@@ -911,6 +922,20 @@ machine = Machine(states=states, transitions=transitions, add_self=False)
 machine.add_model(Matter())
 >>> "MachineError: No initial state configured for machine, must specify when adding model."
 machine.add_model(Matter(), initial='liquid')
+```
+
+Models with multiple states could attach multiple machines using different `model_attribute` values:
+
+```python
+lump = Matter()
+
+lump.state
+>>> 'solid'
+lump.shipping_state
+>>> 'delivered'
+
+matter_machine = Machine(lump, model_field='state', **kwargs)
+shipment_machine = Machine(lump, model_field='shipping_state', **kwargs)
 ```
 
 ### Logging

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,7 +34,7 @@ class TestTransitions(TestCase):
     def tearDown(self):
         pass
 
-    def test_init_machine_with_hello_arguments(self):
+    def test_init_machine_with_hella_arguments(self):
         states = [
             State('State1'),
             'State2',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1013,12 +1013,17 @@ class TestTransitions(TestCase):
         class Model:
             def __init__(self):
                 self.status = None
+                self.state = 'some_value'
 
         m = Machine(Model(), states=['A', 'B'], initial='A', model_attribute='status')
         self.assertEqual(m.model.status, 'A')
+        self.assertEqual(m.model.state, 'some_value')
+
         m.add_transition('move', 'A', 'B')
         m.model.move()
+
         self.assertEqual(m.model.status, 'B')
+        self.assertEqual(m.model.state, 'some_value')
 
     def test_multiple_machines_per_model(self):
         class Model:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -34,7 +34,7 @@ class TestTransitions(TestCase):
     def tearDown(self):
         pass
 
-    def test_init_machine_with_hella_arguments(self):
+    def test_init_machine_with_hello_arguments(self):
         states = [
             State('State1'),
             'State2',
@@ -1008,6 +1008,40 @@ class TestTransitions(TestCase):
         m.model.move()
         self.assertEqual(m.model.state, 'A')
         self.assertEqual(m.model.level, 2)
+
+    def test_dynamic_model_state_attribute(self):
+        class Model:
+            def __init__(self):
+                self.status = None
+
+        m = Machine(Model(), states=['A', 'B'], initial='A', model_attribute='status')
+        self.assertEqual(m.model.status, 'A')
+        m.add_transition('move', 'A', 'B')
+        m.model.move()
+        self.assertEqual(m.model.status, 'B')
+
+    def test_multiple_machines_per_model(self):
+        class Model:
+            def __init__(self):
+                self.state_a = None
+                self.state_b = None
+
+        instance = Model()
+        machine_a = Machine(instance, states=['A', 'B'], initial='A', model_attribute='state_a')
+        machine_a.add_transition('melt', 'A', 'B')
+        machine_b = Machine(instance, states=['A', 'B'], initial='B', model_attribute='state_b')
+        machine_b.add_transition('freeze', 'B', 'A')
+
+        self.assertEqual(instance.state_a, 'A')
+        self.assertEqual(instance.state_b, 'B')
+
+        instance.melt()
+        self.assertEqual(instance.state_a, 'B')
+        self.assertEqual(instance.state_b, 'B')
+
+        instance.freeze()
+        self.assertEqual(instance.state_b, 'A')
+        self.assertEqual(instance.state_a, 'B')
 
 
 class TestWarnings(TestCase):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -290,7 +290,7 @@ class Transition(object):
     def _change_state(self, event_data):
         event_data.machine.get_state(self.source).exit(event_data)
         event_data.machine.set_state(self.dest, event_data.model)
-        event_data.update(event_data.machine.get_model_state(event_data.model).value)
+        event_data.update(getattr(event_data.model, event_data.machine.model_attribute))
         event_data.machine.get_state(self.dest).enter(event_data)
 
     def add_callback(self, trigger, func):
@@ -729,13 +729,10 @@ class Machine(object):
         Returns:
             bool: Whether the model's current state is state.
         """
-        return self._get_model_state_value(model) == state
-
-    def _get_model_state_value(self, model):
-        return getattr(model, self.model_attribute)
+        return getattr(model, self.model_attribute) == state
 
     def get_model_state(self, model):
-        return self.get_state(self._get_model_state_value(model))
+        return self.get_state(getattr(model, self.model_attribute))
 
     def set_state(self, state, model=None):
         """

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -743,8 +743,8 @@ class Machine(object):
         state = self.get_state(state)
         models = self.models if model is None else listify(model)
 
-        for model in models:
-            setattr(model, self.model_attribute, state.value)
+        for mod in models:
+            setattr(mod, self.model_attribute, state.value)
 
     def add_state(self, *args, **kwargs):
         """ Alias for add_states. """
@@ -857,7 +857,8 @@ class Machine(object):
             **kwargs: Additional arguments which can be passed to the created transition.
                 This is useful if you plan to extend Machine.Transition and require more parameters.
         """
-        assert trigger != self.model_attribute, "Trigger name cannot be same as model attribute name."
+        if trigger == self.model_attribute:
+            raise ValueError("Trigger name cannot be same as model attribute name.")
         if trigger not in self.events:
             self.events[trigger] = self._create_event(trigger, self)
             for model in self.models:

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -164,7 +164,7 @@ class GraphMachine(MarkupMachine):
             grph = self.graph_cls(self, title=title if title is not None else self.title)
             self.model_graphs[model] = grph
             try:
-                self.model_graphs[model].set_node_style(self._get_model_state_value(model), 'active')
+                self.model_graphs[model].set_node_style(getattr(model, self.model_attribute), 'active')
             except AttributeError:
                 _LOGGER.info("Could not set active state of diagram")
         try:
@@ -172,7 +172,7 @@ class GraphMachine(MarkupMachine):
         except KeyError:
             _ = self._get_graph(model, title, force_new=True)
             m = self.model_graphs[model]
-        m.roi_state = self._get_model_state_value(model) if show_roi else None
+        m.roi_state = getattr(model, self.model_attribute) if show_roi else None
         return m.get_graph(title=title)
 
     def get_combined_graph(self, title=None, force_new=False, show_roi=False):

--- a/transitions/extensions/diagrams.py
+++ b/transitions/extensions/diagrams.py
@@ -164,7 +164,7 @@ class GraphMachine(MarkupMachine):
             grph = self.graph_cls(self, title=title if title is not None else self.title)
             self.model_graphs[model] = grph
             try:
-                self.model_graphs[model].set_node_style(model.state, 'active')
+                self.model_graphs[model].set_node_style(self._get_model_state_value(model), 'active')
             except AttributeError:
                 _LOGGER.info("Could not set active state of diagram")
         try:
@@ -172,7 +172,7 @@ class GraphMachine(MarkupMachine):
         except KeyError:
             _ = self._get_graph(model, title, force_new=True)
             m = self.model_graphs[model]
-        m.roi_state = model.state if show_roi else None
+        m.roi_state = self._get_model_state_value(model) if show_roi else None
         return m.get_graph(title=title)
 
     def get_combined_graph(self, title=None, force_new=False, show_roi=False):

--- a/transitions/extensions/markup.py
+++ b/transitions/extensions/markup.py
@@ -106,7 +106,7 @@ class MarkupMachine(Machine):
     def _convert_models(self):
         models = []
         for model in self.models:
-            model_def = dict(state=self._get_model_state_value(model))
+            model_def = dict(state=getattr(model, self.model_attribute))
             model_def['name'] = model.name if hasattr(model, 'name') else str(id(model))
             model_def['class-name'] = 'self' if model == self else model.__module__ + "." + model.__class__.__name__
             models.append(model_def)

--- a/transitions/extensions/markup.py
+++ b/transitions/extensions/markup.py
@@ -105,10 +105,10 @@ class MarkupMachine(Machine):
 
     def _convert_models(self):
         models = []
-        for m in self.models:
-            model_def = dict(state=m.state)
-            model_def['name'] = m.name if hasattr(m, 'name') else str(id(m))
-            model_def['class-name'] = 'self' if m == self else m.__module__ + "." + m.__class__.__name__
+        for model in self.models:
+            model_def = dict(state=self._get_model_state_value(model))
+            model_def['name'] = model.name if hasattr(model, 'name') else str(id(model))
+            model_def['class-name'] = 'self' if model == self else model.__module__ + "." + model.__class__.__name__
             models.append(model_def)
         return models
 

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -319,7 +319,7 @@ class HierarchicalMachine(Machine):
 
         """
         if not allow_substates:
-            return self._get_model_state_value(model) == state_name
+            return getattr(model, self.model_attribute) == state_name
 
         return self.get_model_state(model).is_substate_of(state_name)
 
@@ -517,4 +517,4 @@ class HierarchicalMachine(Machine):
 
         event = EventData(self.get_model_state(model), Event('to', self), self,
                           model, args=args, kwargs=kwargs)
-        self._create_transition(self._get_model_state_value(model), state_name).execute(event)
+        self._create_transition(getattr(model, self.model_attribute), state_name).execute(event)


### PR DESCRIPTION
This adds a `model_attribute` argument to Machine which allows specifying the attribute name used in the model for tracking state.

As an added benefit, this also adds ability to attach multiple machines per model.

- Update instances of hard-coded `model.state` access/modification to dynamic model attribute access.
- Update docs and tests

Closes #372 