### PR TITLE
Fix add_ordered_transitions w/o initial state

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -373,6 +373,17 @@ class TestTransitions(TestCase):
         m.next_state()
         self.assertEqual(m.state, 'beginning')
 
+        m = Machine('self', states, initial='beginning')
+        # Partial state machine without the initial state
+        m.add_ordered_transitions(['middle', 'end'])
+        self.assertEqual(m.state, 'beginning')
+        with self.assertRaises(MachineError):
+            m.next_state()
+        m.to_middle()
+        for s in ('end', 'middle', 'end'):
+            m.next_state()
+            self.assertEqual(m.state, s)
+
     def test_ordered_transition_error(self):
         m = Machine(states=['A'], initial='A')
         with self.assertRaises(ValueError):

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -906,7 +906,9 @@ class Machine(object):
                 state to the first state.
             loop_includes_initial (boolean): If no initial state was defined in
                 the machine, setting this to True will cause the _initial state
-                placeholder to be included in the added transitions.
+                placeholder to be included in the added transitions. This argument
+                has no effect if the states argument is passed without the
+                initial state included.
             conditions (str or list): Condition(s) that must pass in order
                 for the transition to take place. Either a list providing the
                 name of a callable, or a list of callables. For the transition
@@ -935,8 +937,12 @@ class Machine(object):
         after = _prep_ordered_arg(len_transitions, after)
         prepare = _prep_ordered_arg(len_transitions, prepare)
         # reorder list so that the initial state is actually the first one
-        idx = states.index(self._initial)
-        states = states[idx:] + states[:idx]
+        try:
+            idx = states.index(self._initial)
+            states = states[idx:] + states[:idx]
+            includes_initial = True
+        except ValueError:
+            includes_initial = False
 
         for i in range(0, len(states) - 1):
             self.add_transition(trigger, states[i], states[i + 1],
@@ -947,9 +953,14 @@ class Machine(object):
                                 prepare=prepare[i],
                                 **kwargs)
         if loop:
+            # omit initial if not loop_includes_initial
+            if includes_initial and not loop_includes_initial:
+                loop_start_state = states[1]
+            else:
+                loop_start_state = states[0]
+
             self.add_transition(trigger, states[-1],
-                                # omit initial if not loop_includes_initial
-                                states[0 if loop_includes_initial else 1],
+                                loop_start_state,
                                 conditions=conditions[-1],
                                 unless=unless[-1],
                                 before=before[-1],


### PR DESCRIPTION
Previous implementation assumed that the initial state of the state
machine must be specified in the states list.

However, the add_ordered_transitions could be useful also when only a
part of the state machine is wanted to have ordered transactions. Think
for example nested state machine where sub-states of a state is wanted
to be traversed in order, perhaps in a loop.

To fix, allow calling add_ordered_transitions with states argument not
including the initial state. In effect, loop_includes_initial argument
has no relevance if the initial state is not present in the states list.