### PR TITLE
AsyncMachine.dispatch now returns a boolean as expected

### DIFF
--- a/transitions/extensions/asyncio.py
+++ b/transitions/extensions/asyncio.py
@@ -237,7 +237,8 @@ class AsyncMachine(Machine):
         Returns:
             bool The truth value of all triggers combined with AND
         """
-        await asyncio.gather(*[getattr(model, trigger)(*args, **kwargs) for model in self.models])
+        results = await asyncio.gather(*[getattr(model, trigger)(*args, **kwargs) for model in self.models])
+        return all(results)
 
     async def callbacks(self, funcs, event_data):
         """ Triggers a list of callbacks """


### PR DESCRIPTION
In https://github.com/pytransitions/transitions/blob/37fd5a31a7ba544701799bcde073f2193c033e0a/transitions/core.py#L1030-L1039 the `dispatch` method returns a boolean.
The AsyncMachine implementation did not return a value.

This PR ensures it does.