### PR TITLE
Use generator instead of list comprehension

### DIFF
--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -850,4 +850,4 @@ class HierarchicalMachine(Machine):
                     res[key] = self._trigger_event(_model, _trigger, value, *args, **kwargs)
             if not res.get(key, None) and _trigger in self.events:
                 res[key] = self.events[_trigger].trigger(_model, self, *args, **kwargs)
-        return None if not res or all([v is None for v in res.values()]) else any(res.values())
+        return None if not res or all(v is None for v in res.values()) else any(res.values())


### PR DESCRIPTION
This is a bit more efficient as we don't need to create a list and can return as soon as any `v is None`.