### PR TITLE
Fallback to __getattribute__ if attribute is not found

### DIFF
--- a/transitions/core.py
+++ b/transitions/core.py
@@ -1167,8 +1167,11 @@ class Machine(object):
                 state = self.get_state(target)
                 return partial(state.add_callback, callback_type[3:])
 
-        # Nothing matched
-        raise AttributeError("'{}' does not exist on <Machine@{}>".format(name, id(self)))
+        try:
+            return self.__getattribute__(name)
+        except AttributeError:
+            # Nothing matched
+            raise AttributeError("'{}' does not exist on <Machine@{}>".format(name, id(self)))
 
 
 class MachineError(Exception):


### PR DESCRIPTION
If we don't maintain the default behavior it makes it impossible to inherit from any `StateMachine` and extend it.
See https://stackoverflow.com/a/31944601/85140 for more information.