### PR TITLE
HierarchicalMachine.to_state() now works with enumerations

### DIFF
--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -667,8 +667,12 @@ class HierarchicalMachine(Machine):
 
         event = EventData(self.get_state(current_state), Event('to', self), self,
                           model, args=args, kwargs=kwargs)
-        event.source_name = current_state
-        event.source_path = current_state.split(self.state_cls.separator)
+        if isinstance(current_state, Enum):
+            event.source_name = current_state.name
+            event.source_path = current_state
+        else:
+            event.source_name = current_state
+            event.source_path = current_state.split(self.state_cls.separator)
         self._create_transition(current_state, state_name).execute(event)
 
     def trigger_event(self, _model, _trigger, *args, **kwargs):


### PR DESCRIPTION
It is sometimes useful to use `to_state()` when testing even if we don't have special separator characters.
Therefor, this method should work with enumerations as states as well.