### PR TITLE
Add Retry mix-in

### DIFF
--- a/transitions/extensions/states.py
+++ b/transitions/extensions/states.py
@@ -5,6 +5,7 @@
     This module contains mix ins which can be used to extend state functionality.
 """
 
+from collections import Counter
 from threading import Timer
 import logging
 import inspect
@@ -159,6 +160,68 @@ class Volatile(State):
             delattr(event_data.model, self.volatile_hook)
         except AttributeError:
             pass
+
+
+
+class Retry(State):
+    """ The Retry mix-in sets a limit on the number of times a state may be
+        re-entered from itself.
+
+        The first time a state is entered it does not count as a retry. Thus with
+        `retries=3` the state can be entered four times before it fails.
+
+        When the retry limit is exceeded, the state is not entered and instead the
+        `on_failure` callback is invoked on the model. For example,
+
+            Retry(retries=3, on_failure='to_failed')
+
+        transitions the model directly to the 'failed' state, if the machine has
+        automatic transitions enabled (the default).
+        
+        Attributes:
+            retries (int): Number of retries to allow before failing.
+            on_failure (str): Function to invoke on the model when the retry limit
+                is excheeded.
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Args:
+            **kwargs: If kwargs contains `retries`, then limit the number of times
+                the state may be re-entered from itself. The argument `on_failure`,
+                which is the function to invoke on the model when the retry limit
+                is exceeded, must also be provided.
+        """
+        self.retries = kwargs.pop('retries', 0)
+        self.on_failure = kwargs.pop('on_failure', None)
+        self.retry_counts = Counter()
+        if self.retries > 0 and self.on_failure is None:
+            raise AttributeError("Retry state requires 'on_failure' when "
+                                 "'retries' is set.")
+        super(Retry, self).__init__(*args, **kwargs)
+
+    def enter(self, event_data):
+        k = id(event_data.model)
+
+        # If we are entering from a different state, then this is our first try;
+        # reset the retry counter.
+        if event_data.transition.source != self.name:
+            _LOGGER.debug('%sRetry limit for state %s reset (came from %s)',
+                          event_data.machine.name, self.name,
+                          event_data.transition.source)
+            self.retry_counts[k] = 0
+
+        # If we have tried too many times, invoke our failure callback instead
+        if self.retry_counts[k] > self.retries > 0:
+            _LOGGER.info('%sRetry count for state %s exceeded limit (%i)',
+                          event_data.machine.name, self.name, self.retries)
+            event_data.machine.callback(self.on_failure, event_data)
+            return
+
+        # Otherwise, increment the retry count and continue per normal
+        _LOGGER.debug('%sRetry count for state %s is now %i',
+                      event_data.machine.name, self.name, self.retry_counts[k])
+        self.retry_counts.update((k,))
+        super(Retry, self).enter(event_data)
 
 
 def add_state_features(*args):


### PR DESCRIPTION
Note: This involved a bit of in-browser coding, so please check for formatting issues and bugs.

This change introduces a Retry mix-in which lets you limit the number of times a state may be re-entered from itself. This is useful if a state represents an operation that may need to be retried a few times, but should eventually give up.

This works really well with the Timeout mix-in:

```
{ 'name': 'PingServer',
  'timeout': 1, 'on_timeout': 'to_PingServer',
  'retries': 3, 'on_failure': 'to_CriticalFailure',
},
```

In this example, the `PingServer` state might involve sending a `ping` packet to a server and expecting a `pong` reply, whereupon it will transition to another state. If the timeout is met, then it would re-enter the `PingServer` state, triggering a second `ping` to be sent. But on the 5th time the state is entered, it will instead transition to `CriticalFailure` without sending another `ping`.