### PR TITLE
Fix diagrams_pygraphviz.Graph.get_graph method when states are enums

### DIFF
--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -280,6 +280,16 @@ class TestEnumWithGraph(TestEnumsAsStates):
         super(TestEnumWithGraph, self).setUp()
         self.machine_cls = MachineFactory.get_predefined(graph=True)
 
+    def test_get_graph(self):
+        m = self.machine_cls(states=self.States, initial=self.States.GREEN)
+        roi = m.get_graph(show_roi=False)
+        self.assertIsNotNone(roi)
+
+    def test_get_graph_show_roi(self):
+        m = self.machine_cls(states=self.States, initial=self.States.GREEN)
+        roi = m.get_graph(show_roi=True)
+        self.assertIsNotNone(roi)
+
 
 @skipIf(enum is None or (pgv is None and gv is None), "enum and (py)graphviz are not available")
 class TestNestedStateGraphEnums(TestNestedStateEnums):

--- a/transitions/extensions/diagrams_pygraphviz.py
+++ b/transitions/extensions/diagrams_pygraphviz.py
@@ -74,7 +74,9 @@ class Graph(BaseGraph):
         if self.roi_state:
             filtered = self.fsm_graph.copy()
             kept_nodes = set()
-            active_state = self.roi_state if filtered.has_node(self.roi_state) else self.roi_state + '_anchor'
+            active_state = self.roi_state.name if hasattr(self.roi_state, 'name') else self.roi_state
+            if not filtered.has_node(self.roi_state):
+                active_state += '_anchor'
             kept_nodes.add(active_state)
 
             # remove all edges that have no connection to the currently active state


### PR DESCRIPTION
The example from `README.md` for `GraphMachine` fails if machine states are enums.