### PR TITLE
Use model_attribute in predicate method name

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1071,25 +1071,31 @@ class TestTransitions(TestCase):
     def test_multiple_machines_per_model(self):
         class Model:
             def __init__(self):
-                self.state_a = None
-                self.state_b = None
+                self.car_state = None
+                self.driver_state = None
 
         instance = Model()
-        machine_a = Machine(instance, states=['A', 'B'], initial='A', model_attribute='state_a')
-        machine_a.add_transition('melt', 'A', 'B')
-        machine_b = Machine(instance, states=['A', 'B'], initial='B', model_attribute='state_b')
-        machine_b.add_transition('freeze', 'B', 'A')
+        machine_a = Machine(instance, states=['A', 'B'], initial='A', model_attribute='car_state')
+        machine_a.add_transition('accelerate_car', 'A', 'B')
+        machine_b = Machine(instance, states=['A', 'B'], initial='B', model_attribute='driver_state')
+        machine_b.add_transition('driving', 'B', 'A')
 
-        self.assertEqual(instance.state_a, 'A')
-        self.assertEqual(instance.state_b, 'B')
+        assert instance.car_state == 'A'
+        assert instance.driver_state == 'B'
+        assert instance.is_car_state_A()
+        assert instance.is_driver_state_B()
 
-        instance.melt()
-        self.assertEqual(instance.state_a, 'B')
-        self.assertEqual(instance.state_b, 'B')
+        instance.accelerate_car()
+        assert instance.car_state == 'B'
+        assert instance.driver_state == 'B'
+        assert not instance.is_car_state_A()
+        assert instance.is_car_state_B()
 
-        instance.freeze()
-        self.assertEqual(instance.state_b, 'A')
-        self.assertEqual(instance.state_a, 'B')
+        instance.driving()
+        assert instance.driver_state == 'A'
+        assert instance.car_state == 'B'
+        assert instance.is_driver_state_A()
+        assert not instance.is_driver_state_B()
 
     def test_initial_not_registered(self):
         m1 = self.machine_cls(states=['A', 'B'], initial=self.machine_cls.state_cls('C'))

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -787,7 +787,11 @@ class Machine(object):
                         self.add_transition('to_%s' % a_state, state.name, a_state)
 
     def _add_model_to_state(self, state, model):
-        self._checked_assignment(model, 'is_%s' % state.name, partial(self.is_state, state.value, model))
+        if self.model_attribute != 'state':
+            meth_name = 'is_%s_%s' % (self.model_attribute, state.name)
+        else:
+            meth_name = 'is_%s' % state.name
+        self._checked_assignment(model, meth_name, partial(self.is_state, state.value, model))
 
         # Add dynamic method callbacks (enter/exit) if there are existing bound methods in the model
         # except if they are already mentioned in 'on_enter/exit' of the defined state


### PR DESCRIPTION
This PR adds `model_attribute` to predicate method name if model_attribute != default value (state)

It needs when we are using multiple states in the model.
Currently `transitions` generates only single method `is_{state_name}`. And if we have the same states in the model as in the test case. ['A', 'B'] for first state and ['A', 'B'] for the second state we can't use predicate methods because the instance already has this predicate for first state

Solutuon: separate predicate methods by name `is_{method_attr}_{state_name}`


