### PR TITLE
Return all nested transitions

### DIFF
--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -664,7 +664,7 @@ class HierarchicalMachine(Machine):
                 while source_path:
                     transitions.extend(self.get_nested_transitions(trigger, source_path, dest_path))
                     source_path.pop()
-                    return transitions
+                return transitions
             else:
                 return self.get_nested_transitions(trigger, None, dest_path)
 


### PR DESCRIPTION
Unless I'm missing something, the return statement is incorrectly indented.
If that's not the case, then the while loop is redundant and can be removed.

We should add a test to verify that this issue does not regress.