### PR TITLE
Fix resolving enums when they are set as nested initial states

### DIFF
--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -293,7 +293,7 @@ class NestedTransition(Transition):
                     scoped_tree[state.name] = OrderedDict()
                     if state.initial:
                         q.append((scoped_tree[state.name], prefix + [state.name],
-                                  [state.states[i] for i in listify(state.initial)]))
+                                  [state.states[i.name] if hasattr(i, 'name') else state.states[i] for i in listify(state.initial)]))
                 if not q:
                     break
                 scoped_tree, prefix, initial_states = q.pop(0)


### PR DESCRIPTION
If we set a nested state's initial value to an enum it doesn't get resolved and raises a KeyError instead.
I'm not sure which test case reproduces this directly though so I'd appriciate if you can write a unit test for this.