### PR TITLE
Treat warnings as errors to not miss unawaited coroutines

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
-filterwarnings = ignore:.*With-statements.*:DeprecationWarning
+filterwarnings =
+    error
+    ignore:.*With-statements.*:DeprecationWarning
 addopts = -x -rf
 junit_family = xunit2


### PR DESCRIPTION
Pytest will now fail on any warning not explictly ignored.
This is a good idea since unawaited coroutines issue a RuntimeWarning instead of an exception. I hope that will change one day but in the meanwhile, this is a good workaround.