### PR TITLE
`listify()` now supports empty weak references

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,6 +13,7 @@ from transitions import Machine, MachineError, State, EventData
 from transitions.core import listify, _prep_ordered_arg
 from unittest import TestCase, skipIf
 import warnings
+import weakref
 
 try:
     from unittest.mock import MagicMock
@@ -62,6 +63,13 @@ class TestTransitions(TestCase):
         self.assertEqual(listify(None), [])
         self.assertEqual(listify((4, 5)), (4, 5))
         self.assertEqual(listify([1, 3]), [1, 3])
+        
+        class Foo:
+            pass
+        obj = Foo()
+        proxy = weakref.proxy(obj)
+        del obj
+        self.assertEqual(listify(proxy), [proxy])
 
     def test_property_initial(self):
         states = ['A', 'B', 'C', 'D']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,7 +63,7 @@ class TestTransitions(TestCase):
         self.assertEqual(listify(None), [])
         self.assertEqual(listify((4, 5)), (4, 5))
         self.assertEqual(listify([1, 3]), [1, 3])
-        
+
         class Foo:
             pass
         obj = Foo()

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -50,7 +50,11 @@ def listify(obj):
     if obj is None:
         return []
 
-    return obj if isinstance(obj, (list, tuple, EnumMeta)) else [obj]
+    try:
+        return obj if isinstance(obj, (list, tuple, EnumMeta)) else [obj]
+    except ReferenceError:
+        # obj is an empty weakref
+        return [obj]
 
 
 def _prep_ordered_arg(desired_length, arguments=None):


### PR DESCRIPTION
If you attempt to listify an empty weak reference you get a `ReferenceError` since comparing their type to something is no longer possible.
Instead, just return a list containing the object.