### PR TITLE
Make counter example use `HierarchicalMachine` explicitly to be more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -1453,7 +1453,7 @@ transitions = [
     ['count', 'collecting', 'counting']
 ]
 
-collector = Machine(states=states, transitions=transitions, initial='waiting')
+collector = HierarchicalMachine(states=states, transitions=transitions, initial='waiting')
 collector.collect()  # collecting
 collector.count()  # let's see what we got; counting_1
 collector.increase()  # counting_2

--- a/README.md
+++ b/README.md
@@ -1136,9 +1136,9 @@ However, classes can also be directly imported from `transitions.extensions`. Th
 To use a feature-rich state machine, one could write:
 
 ```python
-from transitions.extensions import LockedHierarchicalGraphMachine as Machine
+from transitions.extensions import LockedHierarchicalGraphMachine as LHGMachine
 
-machine = Machine(model, states, transitions)
+machine = LHGMachine(model, states, transitions)
 ```
 
 #### <a name="diagrams"></a> Diagrams
@@ -1169,14 +1169,14 @@ With `Model.get_graph()` you can get the current graph or the region of interest
 ```python
 # import transitions
 
-from transitions.extensions import GraphMachine as Machine
+from transitions.extensions import GraphMachine
 m = Model()
 # without further arguments pygraphviz will be used
-machine = Machine(model=m, ...)
+machine = GraphMachine(model=m, ...)
 # when you want to use graphviz explicitly
-machine = Machine(model=m, use_pygraphviz=False, ...)
+machine = GraphMachine(model=m, use_pygraphviz=False, ...)
 # in cases where auto transitions should be visible
-machine = Machine(model=m, show_auto_transitions=True, ...)
+machine = GraphMachine(model=m, show_auto_transitions=True, ...)
 
 # draw the whole graph ...
 m.get_graph().draw('my_state_diagram.png', prog='dot')
@@ -1192,7 +1192,7 @@ This produces something like this:
 References and partials passed as callbacks will be resolved as good as possible:
 
 ```python
-from transitions.extensions import GraphMachine as Machine
+from transitions.extensions import GraphMachine
 from functools import partial
 
 
@@ -1204,13 +1204,13 @@ class Model:
 
 
 model = Model()
-machine = Machine(model=model, states=['A', 'B', 'C'],
-                  transitions=[
-                      {'trigger': 'clear', 'source': 'B', 'dest': 'A', 'conditions': model.clear_state},
-                      {'trigger': 'clear', 'source': 'C', 'dest': 'A',
-                       'conditions': partial(model.clear_state, False, force=True)},
-                  ],
-                  initial='A', show_conditions=True)
+machine = GraphMachine(model=model, states=['A', 'B', 'C'],
+                       transitions=[
+                           {'trigger': 'clear', 'source': 'B', 'dest': 'A', 'conditions': model.clear_state},
+                           {'trigger': 'clear', 'source': 'C', 'dest': 'A',
+                            'conditions': partial(model.clear_state, False, force=True)},
+                       ],
+                       initial='A', show_conditions=True)
 
 model.get_graph().draw('my_state_diagram.png', prog='dot')
 ```
@@ -1231,7 +1231,7 @@ To create a nested state, either import `NestedState` from transitions or use a 
 Optionally, `initial` can be used to define a sub state to transit to, when the nested state is entered.
 
 ```python
-from transitions.extensions import HierarchicalMachine as Machine
+from transitions.extensions import HierarchicalMachine
 
 states = ['standing', 'walking', {'name': 'caffeinated', 'children':['dithering', 'running']}]
 transitions = [
@@ -1242,7 +1242,7 @@ transitions = [
   ['relax', 'caffeinated', 'standing']
 ]
 
-machine = Machine(states=states, transitions=transitions, initial='standing', ignore_invalid_triggers=True)
+machine = HierarchicalMachine(states=states, transitions=transitions, initial='standing', ignore_invalid_triggers=True)
 
 machine.walk() # Walking now
 machine.stop() # let's stop for a moment
@@ -1442,7 +1442,7 @@ count_trans = [
     ['reset', '*', '1']
 ]
 
-counter = Machine(states=count_states, transitions=count_trans, initial='1')
+counter = HierarchicalMachine(states=count_states, transitions=count_trans, initial='1')
 
 counter.increase() # love my counter
 states = ['waiting', 'collecting', {'name': 'counting', 'children': counter}]
@@ -1533,7 +1533,7 @@ collector_conf = {
     'initial': 'waiting'
 }
 
-collector = Machine(**collector_conf)
+collector = HierarchicalMachine(**collector_conf)
 collector.collect()
 collector.count()
 collector.increase()
@@ -1546,12 +1546,12 @@ In cases where event dispatching is done in threads, one can use either `LockedM
 This does not save you from corrupting your machine by tinkering with member variables of your model or state machine.
 
 ```python
-from transitions.extensions import LockedMachine as Machine
+from transitions.extensions import LockedMachine
 from threading import Thread
 import time
 
 states = ['A', 'B', 'C']
-machine = Machine(states=states, initial='A')
+machine = LockedMachine(states=states, initial='A')
 
 # let us assume that entering B will take some time
 thread = Thread(target=machine.to_B)
@@ -1567,7 +1567,7 @@ machine.new_attrib = 42 # not synchronized! will mess with execution order
 Any python context manager can be passed in via the `machine_context` keyword argument:
 
 ```python
-from transitions.extensions import LockedMachine as Machine
+from transitions.extensions import LockedMachine
 from threading import RLock
 
 states = ['A', 'B', 'C']
@@ -1575,7 +1575,7 @@ states = ['A', 'B', 'C']
 lock1 = RLock()
 lock2 = RLock()
 
-machine = Machine(states=states, initial='A', machine_context=[lock1, lock2])
+machine = LockedMachine(states=states, initial='A', machine_context=[lock1, lock2])
 ```
 
 Any contexts via `machine_model` will be shared between all models registered with the `Machine`.


### PR DESCRIPTION
If you run it with the regular `Machine` (imported from `transitions`) you'll get this error:

```
In [14]: collector = Machine(states=states, transitions=transitions, initial='waiting')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-14-cb0d383f0648> in <module>
----> 1 collector = Machine(states=states, transitions=transitions, initial='waiting')

~/.virtualenvs/jst/lib/python3.9/site-packages/transitions/core.py in __init__(self, model, states, initial, transitions, send_event, auto_transitions, ordered_transitions, ignore_invalid_triggers, before_state_change, after_state_change, name, queued, prepare_event, finalize_event, model_attribute, on_exception, **kwargs)
    577
    578         if states is not None:
--> 579             self.add_states(states)
    580
    581         if initial is not None:

~/.virtualenvs/jst/lib/python3.9/site-packages/transitions/core.py in add_states(self, states, on_enter, on_exit, ignore_invalid_triggers, **kwargs)
    806                 if 'ignore_invalid_triggers' not in state:
    807                     state['ignore_invalid_triggers'] = ignore
--> 808                 state = self._create_state(**state)
    809             self.states[state.name] = state
    810             for model in self.models:

~/.virtualenvs/jst/lib/python3.9/site-packages/transitions/core.py in _create_state(cls, *args, **kwargs)
    638     @classmethod
    639     def _create_state(cls, *args, **kwargs):
--> 640         return cls.state_cls(*args, **kwargs)
    641
    642     @property

TypeError: __init__() got an unexpected keyword argument 'children'
```