### PR TITLE
setup.cfg: change description-file to description_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [check-manifest]
 ignore =


### PR DESCRIPTION
UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead.

Signed-off-by: Conrad Kostecki <conikost@gentoo.org>