### PR TITLE
Missing "Machine" import

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The following snippets illustrate several ways to achieve the same goal:
 
 ```python
 # import Machine and State class
-from transitions import State
+from transitions import Machine, State
 
 # Create a list of 3 states to pass to the Machine
 # initializer. We can mix types; in this case, we


### PR DESCRIPTION
The main `README.md` file, section "Non-Quickstart/State", is missing an import in the example.

```
# import Machine and State class
from transitions import State
```

It should be

```
# import Machine and State class
from transitions import Machine, State
```

Fix for issue #541 