### PR TITLE
asyncio: Fix setting AsyncTimeout._on_timeout trigger, when timeout=0

### DIFF
--- a/transitions/extensions/asyncio.py
+++ b/transitions/extensions/asyncio.py
@@ -586,7 +586,7 @@ class AsyncTimeout(AsyncState):
             except KeyError:
                 raise AttributeError("Timeout state requires 'on_timeout' when timeout is set.") from None
         else:
-            self._on_timeout = kwargs.pop("on_timeout", [])
+            self.on_timeout = kwargs.pop("on_timeout", None)
         self.runner = {}
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
## Bug description
I wanted to initialise `AsyncTimeout` state with timeout=0, so I can set timeout after initialisation before/after entering state. But trigger is not called after setting timeout > 0, entering the state and timeout has passed.

So in my project, I set on_timeout along with the timeout before entering to state and it's working.

## Root cause analyse result
`AsyncTimeout._on_timeout` is a list of triggers and there is a `on_timeout` setter that listifies value before setting. `AsyncTimeout.__init__` uses setter if `timeout > 0`, but it passes directly if `timeout = 0`.