### PR TITLE
Add trailing newline to graph's node labels

### DIFF
--- a/transitions/extensions/diagrams_base.py
+++ b/transitions/extensions/diagrams_base.py
@@ -74,7 +74,8 @@ class BaseGraph(object):
                 label += r"\l- exit:\l  + " + r"\l  + ".join(state["on_exit"])
             if "timeout" in state:
                 label += r'\l- timeout(' + state['timeout'] + 's) -> (' + ', '.join(state['on_timeout']) + ')'
-        return label
+        # end each label with a left-aligned newline
+        return label + r"\l"
 
     def _get_state_names(self, state):
         if isinstance(state, (list, tuple, set)):

--- a/transitions/extensions/diagrams_base.py
+++ b/transitions/extensions/diagrams_base.py
@@ -1,7 +1,7 @@
 """
     transitions.extensions.diagrams_base
     ------------------------------------
-z
+
     The class BaseGraph implements the common ground for Graphviz backends.
 """
 


### PR DESCRIPTION
Fixes #582

I tested this with combinations: `on_enter`, `on_enter+on_exit`, `timeout+on_timeout`, and  `on_enter+timeout+on_timeout`
```python
states = [
    {
        "name": "initial",
        "on_enter": ["this is odd", "see?"],
        "on_exit": ["this is odd", "see?"],
        "timeout": 30,
        "on_timeout": ["do_something", "do_something"],
    }
]
```