### PR TITLE
Catch `BaseException` instead of `Exception`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Bug #594: Fix may_<trigger> always returning false for internal transitions (thanks @a-schade)
 - PR #592: Pass investigated transition to `EventData` context in 'may' check (thanks @msclock)
 - PR #634: Improve the handling of diagrams when working with parallel states, especially when using the show_roi option (thanks @seanxlliu)
+- Bug #619/#639: `Exception` is not broad enough and does not catch `asyncio.CancelledError` or `KeyboardInterrupt`; use `BaseException` instead (thanks @e0lithic and @ofacklam)
 - '_anchor' suffix has been removed for (py)graphviz cluster node anchors
 - local testing switched from [tox](https://github.com/tox-dev/tox) to [nox](https://github.com/wntrblm/nox)
 - PR #633: Remove surrounding whitespace from docstrings (thanks @artofhuman)

--- a/transitions/core.py
+++ b/transitions/core.py
@@ -414,7 +414,7 @@ class Event(object):
         try:
             if self._is_valid_source(event_data.state):
                 self._process(event_data)
-        except Exception as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
+        except BaseException as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
             event_data.error = err
             if self.machine.on_exception:
                 self.machine.callbacks(self.machine.on_exception, event_data)
@@ -424,7 +424,7 @@ class Event(object):
             try:
                 self.machine.callbacks(self.machine.finalize_event, event_data)
                 _LOGGER.debug("%sExecuted machine finalize callbacks", self.machine.name)
-            except Exception as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
+            except BaseException as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
                 _LOGGER.error("%sWhile executing finalize callbacks a %s occurred: %s.",
                               self.machine.name,
                               type(err).__name__,
@@ -1224,7 +1224,7 @@ class Machine(object):
             try:
                 self._transition_queue[0]()
                 self._transition_queue.popleft()
-            except Exception:
+            except BaseException:
                 # if a transition raises an exception, clear queue and delegate exception handling
                 self._transition_queue.clear()
                 raise

--- a/transitions/extensions/asyncio.py
+++ b/transitions/extensions/asyncio.py
@@ -181,7 +181,7 @@ class AsyncEvent(Event):
         try:
             if self._is_valid_source(event_data.state):
                 await self._process(event_data)
-        except Exception as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
+        except BaseException as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
             _LOGGER.error("%sException was raised while processing the trigger: %s", self.machine.name, err)
             event_data.error = err
             if self.machine.on_exception:
@@ -455,7 +455,7 @@ class AsyncMachine(Machine):
         while self._transition_queue_dict[id(model)]:
             try:
                 await self._transition_queue_dict[id(model)][0]()
-            except Exception:
+            except BaseException:
                 # if a transition raises an exception, clear queue and delegate exception handling
                 self._transition_queue_dict[id(model)].clear()
                 raise
@@ -503,7 +503,7 @@ class HierarchicalAsyncMachine(HierarchicalMachine, AsyncMachine):
             with self():
                 res = await self._trigger_event_nested(event_data, trigger, None)
             event_data.result = self._check_event_result(res, event_data.model, trigger)
-        except Exception as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
+        except BaseException as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
             event_data.error = err
             if self.on_exception:
                 await self.callbacks(self.on_exception, event_data)
@@ -513,7 +513,7 @@ class HierarchicalAsyncMachine(HierarchicalMachine, AsyncMachine):
             try:
                 await self.callbacks(self.finalize_event, event_data)
                 _LOGGER.debug("%sExecuted machine finalize callbacks", self.name)
-            except Exception as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
+            except BaseException as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
                 _LOGGER.error("%sWhile executing finalize callbacks a %s occurred: %s.",
                               self.name,
                               type(err).__name__,

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -812,7 +812,7 @@ class HierarchicalMachine(Machine):
             with self():
                 res = self._trigger_event_nested(event_data, trigger, None)
             event_data.result = self._check_event_result(res, event_data.model, trigger)
-        except Exception as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
+        except BaseException as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
             event_data.error = err
             if self.on_exception:
                 self.callbacks(self.on_exception, event_data)
@@ -822,7 +822,7 @@ class HierarchicalMachine(Machine):
             try:
                 self.callbacks(self.finalize_event, event_data)
                 _LOGGER.debug("%sExecuted machine finalize callbacks", self.name)
-            except Exception as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
+            except BaseException as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
                 _LOGGER.error("%sWhile executing finalize callbacks a %s occurred: %s.",
                               self.name,
                               type(err).__name__,


### PR DESCRIPTION
`Exception` is not broad enough and does not catch `asyncio.CancelledError` or `KeyboardInterrupt`. `transitions` will exclusively catch `BaseException` from now on.

This has to major implications: First `on_exception` is not called when a task is cancelled. This will happen when an asynchronous event cancels currently running callbacks or a KeyboardInterrupt is called.  Second, when `queue=True`
`CancelledError` will not cause the queue to get cleared and render the machine unusable from thereon. 