### PR TITLE
Update test parameters

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,3 @@
 [run]
 source = transitions
-include = */transitions/*
 relative_files = True

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -47,9 +47,10 @@ jobs:
           coverage run -m pytest --doctest-modules tests/
           coverage lcov --ignore-errors
       - name: Coveralls Parallel
+        if: contains(matrix.extras, 'mypy')
         uses: coverallsapp/github-action@v2
         with:
-#          flag-name: run-${{ join(matrix.*, '-') }}
+          flag-name: run-${{ join(matrix.*, '-') }}
           parallel: true
   finish:
     needs: test

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,13 +44,18 @@ jobs:
           python -c "print 'hello'" > /dev/null 2>&1 || pip install -r requirements_mypy.txt
       - name: Test with pytest
         run: |
-          coverage run --source=transitions -m pytest --doctest-modules tests/
-          coverage xml --ignore-errors
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+          coverage run -m pytest --doctest-modules tests/
+          coverage lcov --ignore-errors
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@v2
         with:
-          env_vars: OS,PYTHON
-          fail_ci_if_error: true
-          files: ./coverage.xml
-          name: codecov-umbrella
-          verbose: true
+          flag-name: run-${{ join(matrix.*, '-') }}
+          parallel: true
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@v2
+      with:
+        parallel-finished: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: run-${{ join(matrix.*, '-') }}
+#          flag-name: run-${{ join(matrix.*, '-') }}
           parallel: true
   finish:
     needs: test

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         extras: ["[diagrams]"]
         include:
-          - python-version: "3.11"
+          - python-version: "3.12"
             extras: "[]"
-          - python-version: "3.11"
+          - python-version: "3.12"
             extras: "[diagrams,mypy]"
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,9 +23,9 @@ jobs:
             extras: "[diagrams,mypy]"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@v2
-      with:
-        parallel-finished: true
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,16 +5,16 @@ name: pytest
 
 on:
   push:
-    branches: [ master, dev-gha ]
+    branches: [master, dev-gha]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         extras: ["[diagrams]"]
         include:
           - python-version: "3.11"
@@ -23,34 +23,34 @@ jobs:
             extras: "[diagrams,mypy]"
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
-        python -m pip install -U -r requirements_test.txt
-    - name: Install dependencies for diagrams
-      if: contains(matrix.extras, 'diagrams')
-      run: |
-        sudo apt-get install libgraphviz-dev graphviz
-        python -m pip install -r requirements.txt -r requirements_diagrams.txt 
-    - name: Install dependencies for mypy
-      if: contains(matrix.extras, 'mypy')
-      run: |
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install -U -r requirements_test.txt
+      - name: Install dependencies for diagrams
+        if: contains(matrix.extras, 'diagrams')
+        run: |
+          sudo apt-get install libgraphviz-dev graphviz
+          python -m pip install -r requirements.txt -r requirements_diagrams.txt
+      - name: Install dependencies for mypy
+        if: contains(matrix.extras, 'mypy')
+        run: |
           python -c "print 'hello'" > /dev/null 2>&1 || pip install -r requirements_mypy.txt
-    - name: Test with pytest
-      run: |
-        coverage run --source=transitions -m pytest --doctest-modules tests/
-        coverage xml --ignore-errors
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        env_vars: OS,PYTHON
-        fail_ci_if_error: true
-        files: ./coverage.xml
-        name: codecov-umbrella
-        verbose: true
+      - name: Test with pytest
+        run: |
+          coverage run --source=transitions -m pytest --doctest-modules tests/
+          coverage xml --ignore-errors
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          files: ./coverage.xml
+          name: codecov-umbrella
+          verbose: true

--- a/conftest.py
+++ b/conftest.py
@@ -15,8 +15,8 @@ except ImportError:
 async_files = ['test_async.py', 'asyncio.py']
 
 
-def pytest_ignore_collect(path):
+def pytest_ignore_collect(collection_path):
     """Text collection function executed by pytest"""
-    if not WITH_ASYNC and basename(str(path)) in async_files:
+    if not WITH_ASYNC and basename(str(collection_path)) in async_files:
         return True
     return False

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,21 +1,17 @@
 import nox
 
 
-python = ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
+python = ["2.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 nox.options.stop_on_first_error = True
 
 
-@nox.session(
-    python=python[-1]
-)
+@nox.session(python=python[-1])
 def test_check_manifest(session):
     session.install("check-manifest")
     session.run("check-manifest")
 
 
-@nox.session(
-    python=python[-1]
-)
+@nox.session(python=python[-1])
 def test_mypy(session):
     session.install(".")
     session.install("-rrequirements_test.txt")
@@ -24,9 +20,7 @@ def test_mypy(session):
     session.run("pytest", "-nauto", "--doctest-modules", "tests/")
 
 
-@nox.session(
-    python=python
-)
+@nox.session(python=python)
 def test(session):
     session.install(".")
     session.install("-rrequirements_test.txt")
@@ -34,9 +28,7 @@ def test(session):
     session.run("pytest", "-nauto", "tests/")
 
 
-@nox.session(
-    python=python[-1]
-)
+@nox.session(python=python[-1])
 def test_no_gv(session):
     session.install(".")
     session.install("-rrequirements_test.txt")

--- a/setup.py
+++ b/setup.py
@@ -2,26 +2,29 @@ import codecs
 import sys
 from setuptools import setup, find_packages
 
-with open('transitions/version.py') as f:
+with open("transitions/version.py") as f:
     exec(f.read())
 
-with codecs.open('README.md', 'r', 'utf-8') as f:
+with codecs.open("README.md", "r", "utf-8") as f:
     import re
+
     # cut the badges from the description and also the TOC which is currently not working on PyPi
     regex = r"([\s\S]*)## Quickstart"
     readme = f.read()
 
     long_description = re.sub(regex, "## Quickstart", readme, 1)
-    assert long_description[:13] == '## Quickstart'  # Description should start with a headline (## Quickstart)
+    assert (
+        long_description[:13] == "## Quickstart"
+    )  # Description should start with a headline (## Quickstart)
 
-tests_require = ['mock', 'tox', 'graphviz', 'pygraphviz']
+tests_require = ["mock", "tox", "graphviz", "pygraphviz"]
 
-extras_require = {'diagrams': ['pygraphviz']}
+extras_require = {"diagrams": ["pygraphviz"]}
 
 extra_setuptools_args = {}
-if 'setuptools' in sys.modules:
-    extras_require['test'] = ['pytest']
-    tests_require.append('pytest')
+if "setuptools" in sys.modules:
+    extras_require["test"] = ["pytest"]
+    tests_require.append("pytest")
 
 setup(
     name="transitions",
@@ -29,32 +32,33 @@ setup(
     description="A lightweight, object-oriented Python state machine implementation with many extensions.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    author='Tal Yarkoni',
-    author_email='tyarkoni@gmail.com',
-    maintainer='Alexander Neumann',
-    maintainer_email='aleneum@gmail.com',
-    url='http://github.com/pytransitions/transitions',
-    packages=find_packages(exclude=['tests', 'test_*']),
-    package_data={'transitions': ['py.typed', 'data/*'],
-                  'transitions.tests': ['data/*']
-                  },
+    author="Tal Yarkoni",
+    author_email="tyarkoni@gmail.com",
+    maintainer="Alexander Neumann",
+    maintainer_email="aleneum@gmail.com",
+    url="http://github.com/pytransitions/transitions",
+    packages=find_packages(exclude=["tests", "test_*"]),
+    package_data={
+        "transitions": ["py.typed", "data/*"],
+        "transitions.tests": ["data/*"],
+    },
     include_package_data=True,
-    install_requires=['six'],
+    install_requires=["six"],
     extras_require=extras_require,
     tests_require=tests_require,
-    license='MIT',
-    download_url='https://github.com/pytransitions/transitions/archive/%s.tar.gz' % __version__,
+    license="MIT",
+    download_url="https://github.com/pytransitions/transitions/archive/%s.tar.gz"
+    % __version__,
     classifiers=[
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
-    **extra_setuptools_args
+    **extra_setuptools_args,
 )

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -435,6 +435,21 @@ class TestAsync(TestTransitions):
 
         asyncio.run(run())
 
+    def test_on_exception_finalize(self):
+        mock = MagicMock()
+
+        def finalize():
+            mock()
+            raise RuntimeError("Could not finalize")
+
+        m = self.machine_cls(states=['A', 'B'], initial='A', finalize_event=finalize)
+
+        async def run():
+            self.assertTrue(await m.to_B())
+            self.assertTrue(mock.called)
+
+        asyncio.run(run())
+
     def test_weakproxy_model(self):
         d = DummyModel()
         pr = weakref.proxy(d)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -211,7 +211,7 @@ class TestParallel(TestNested):
                       ))]
                  ))]
             ))]
-        )
+        )  # type: ignore
         m = self.machine_cls()
         self.assertEqual(tree, m.build_state_tree(states, sep))
         self.assertEqual(states, _build_state_list(tree, sep))

--- a/transitions/extensions/asyncio.py
+++ b/transitions/extensions/asyncio.py
@@ -189,8 +189,14 @@ class AsyncEvent(Event):
             else:
                 raise
         finally:
-            await self.machine.callbacks(self.machine.finalize_event, event_data)
-            _LOGGER.debug("%sExecuted machine finalize callbacks", self.machine.name)
+            try:
+                await self.machine.callbacks(self.machine.finalize_event, event_data)
+                _LOGGER.debug("%sExecuted machine finalize callbacks", self.machine.name)
+            except BaseException as err:  # pylint: disable=broad-except; Exception will be handled elsewhere
+                _LOGGER.error("%sWhile executing finalize callbacks a %s occurred: %s.",
+                              self.machine.name,
+                              type(err).__name__,
+                              str(err))
         return event_data.result
 
     async def _process(self, event_data):


### PR DESCRIPTION
Add Python 3.12 and remove 3.7 from testing. This also adjusts the signature of `pytest_ignore_collect`.