### PR TITLE
fix `pytest_ignore_collect` not to block default pytest code

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,4 +19,4 @@ def pytest_ignore_collect(collection_path):
     """Text collection function executed by pytest"""
     if not WITH_ASYNC and basename(str(collection_path)) in async_files:
         return True
-    return False
+    return None


### PR DESCRIPTION
Fix `pytest_ignore_collect` hook implementation to return `None` rather than `False` when the path ought not to be ignored.  This is necessary to enable the default pytest implementation of `pytest_ignore_collect()` to be used.  Otherwise, the default rules are never applied and e.g. `--ignore` does not work.

I've also reported https://github.com/pytest-dev/pytest/issues/12383 about the misleading documentation.