### PR TITLE
fix: allow a list of machines in "parallel" 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
   - Made `transitions.core.(Async)TransitionConfigDict` a `TypedDict` which can be used to spot parameter errors during static analysis
   - `Machine.add_transitions` and `Machine.__init__` expect a `Sequence` of configurations for transitions now
   - Added 'async' callbacks to types in `asyncio` extension
+- Bug #687: Instances of `HierarchicalMachine` can now directly be passed to "parallel" keyword in constructor; Machine states will be processed as a list and thus must be unique (thanks @translunar)
 
 ## 0.9.2 (August 2024)
 

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -263,6 +263,14 @@ class TestParallel(TestNested):
         assert m.is_P_2(allow_substates=True)
         assert not m.is_A(allow_substates=True)
 
+    def test_reuse(self):
+        a = self.machine_cls(states=["A", "B"], initial="A")
+        b = self.machine_cls(states=["C", "D"], initial="D")
+        c = self.machine_cls(states=["A", {"name": "X", "parallel": [a, b]}], initial="A")
+        assert c.to_X()
+        assert c.state == ["X{}A".format(self.state_cls.separator),
+                           "X{}D".format(self.state_cls.separator)]
+
 
 @skipIf(pgv is None, "pygraphviz is not available")
 class TestParallelWithPyGraphviz(TestParallel):

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -966,6 +966,7 @@ class HierarchicalMachine(Machine):
         if state_parallel:
             state_children = state_parallel
             state['initial'] = [s['name'] if isinstance(s, dict)
+                                else s.initial if isinstance(s, HierarchicalMachine)
                                 else s for s in state_children]
         else:
             state_children = state.pop('children', state.pop('states', []))


### PR DESCRIPTION
… and thus initial to be a (list of) machines

- part of #507
- note that machine states must be unique!