### PR TITLE
Apply string_type checks and Enum checks in the correct order

### DIFF
--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, StrEnum
 from unittest import TestCase, skipIf
 
 from transitions.core import Machine
@@ -383,6 +383,19 @@ class TestNestedStateEnums(TestEnumsAsStates):
 
         ref_state = [P.P1, [Q.Q1, [[[X.X1, X.X2], B.B2], A.A2]]]
         self.assertEqual(ref_state, m.state)
+
+
+class TestNestedStateStrEnums(TestNestedStateEnums):
+
+    def setUp(self):
+        super().setUp()
+
+        class States(StrEnum):
+            RED = "red"
+            YELLOW = "yellow"
+            GREEN = "green"
+
+        self.States = States
 
 
 @skipIf(enum is None or (pgv is None and gv is None), "enum and (py)graphviz are not available")

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -695,12 +695,12 @@ class HierarchicalMachine(Machine):
         """
         with self():
             source_path = [] if source == "*" \
-                else source.split(self.state_cls.separator) if isinstance(source, string_types) \
                 else self._get_enum_path(source) if isinstance(source, Enum) \
+                else source.split(self.state_cls.separator) if isinstance(source, string_types) \
                 else self._get_state_path(source)
             dest_path = [] if dest == "*" \
-                else dest.split(self.state_cls.separator) if isinstance(dest, string_types) \
                 else self._get_enum_path(dest) if isinstance(dest, Enum) \
+                else dest.split(self.state_cls.separator) if isinstance(dest, string_types) \
                 else self._get_state_path(dest)
             matches = self.get_nested_transitions(trigger, source_path, dest_path)
             # only consider delegations when source_path contains a nested state (len > 1)

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -417,13 +417,13 @@ class HierarchicalMachine(Machine):
         )
 
     def __call__(self, to_scope=None):
-        if isinstance(to_scope, string_types):
+        if isinstance(to_scope, Enum):
+            state = self.states[to_scope.name]
+            to_scope = (state, state.states, state.events, self.prefix_path + [to_scope.name])
+        elif isinstance(to_scope, string_types):
             state_name = to_scope.split(self.state_cls.separator)[0]
             state = self.states[state_name]
             to_scope = (state, state.states, state.events, self.prefix_path + [state_name])
-        elif isinstance(to_scope, Enum):
-            state = self.states[to_scope.name]
-            to_scope = (state, state.states, state.events, self.prefix_path + [to_scope.name])
         elif to_scope is None:
             if self._stack:
                 to_scope = self._stack[0]


### PR DESCRIPTION
Proposal to fix #695. See issues for details about the problems this PR solves. 

I've added a test that inherit from the current Nested Enum test, and changes the set-up to use StrEnum. Running it produces a crash when resolving the initial state, and a fail test on `get_transitions`. The following commits fix these failures. 

One more change is needed to correctly use `_add_enum_state`, I'll try to add a test to assert that the correct exception is raised when using the separator in an Enum Member name first. 