### PR TITLE
Fix #706: adding edges to the Nested Graphs Mermaid diagrams even when their transitions do not have labels

### DIFF
--- a/transitions/extensions/diagrams_mermaid.py
+++ b/transitions/extensions/diagrams_mermaid.py
@@ -214,8 +214,6 @@ class NestedGraph(Graph):
 
         for src, dests in edges_attr.items():
             for dst, attr in dests.items():
-                if not attr["label"]:
-                    continue
                 container.append("{source} --> {dest}: {label}".format(**attr))
 
     def _create_edge_attr(self, src, dst, transition):


### PR DESCRIPTION
See #706 