### PR TITLE
fix: only process CancellationExceptions triggered by AsyncMachine

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Bug #688: `Machine.remove_transitions` did not work with `State` and `Enum` even though the signature implied this (thanks @hookokoko)
 - PR #696: Improve handling of `StrEnum` which were previously confused as string (thanks @jbrocher)
 - Bug #697: An empty string as a destination made a transition internal but only `dest=None` should do this (thanks @rudy-lath-vizio)
+- Bug #704: `AsyncMachine` processed all `CancelledErrors` but will from now on only do so if the error message is equal to `asyncio.CANCELLED_MSG`; this should make bypassing catch clauses easier; requires Python 3.11+ (thanks @Salier13)
 
 ## 0.9.3 (July 2024)
 

--- a/transitions/extensions/asyncio.pyi
+++ b/transitions/extensions/asyncio.pyi
@@ -13,6 +13,8 @@ from ..core import StateIdentifier, CallbackList
 
 _LOGGER: Logger
 
+CANCELLED_MSG: str = ...
+
 AsyncCallbackFunc = Callable[..., Coroutine[Any, Any, Optional[bool]]]
 AsyncCallback = Union[str, AsyncCallbackFunc]
 AsyncCallbacksArg = Optional[Union[Callback, Iterable[Callback], AsyncCallback, Iterable[AsyncCallback]]]


### PR DESCRIPTION
msg parameter of cancel_running_transitions is marked deprecated

this closes #704