### PR TITLE
Swallowing a BaseException is not allowed.

### DIFF
--- a/transitions/core.py
+++ b/transitions/core.py
@@ -422,7 +422,7 @@ class Event(object):
             event_data.error = err
             if self.machine.on_exception:
                 self.machine.callbacks(self.machine.on_exception, event_data)
-            else:
+            if not self.machine.on_exception or not isinstance(err, Exception):
                 raise
         finally:
             try:
@@ -917,7 +917,7 @@ class Machine(object):
                     event_data.error = err
                     if self.on_exception:
                         self.callbacks(self.on_exception, event_data)
-                    else:
+                    if not self.on_exception or not isinstance(err, BaseException):
                         raise
         return False
 

--- a/transitions/extensions/nesting.py
+++ b/transitions/extensions/nesting.py
@@ -790,7 +790,7 @@ class HierarchicalMachine(Machine):
                         event_data.error = err
                         if self.on_exception:
                             self.callbacks(self.on_exception, event_data)
-                        else:
+                        if not self.on_exception or not isinstance(err, Exception):
                             raise
                 source_path.pop(-1)
         if path:
@@ -916,7 +916,7 @@ class HierarchicalMachine(Machine):
             event_data.error = err
             if self.on_exception:
                 self.callbacks(self.on_exception, event_data)
-            else:
+            if not self.on_exception or not isinstance(err, Exception):
                 raise
         finally:
             try:
@@ -927,6 +927,8 @@ class HierarchicalMachine(Machine):
                               self.name,
                               type(err).__name__,
                               str(err))
+                if not isinstance(err, Exception):
+                    raise
         return event_data.result
 
     def _add_model_to_state(self, state, model):


### PR DESCRIPTION
Python basically forbids swallowing a `BaseException` that's not an `Exception`.

(You do not want a `KeyboardInterrupt` or a `SystemExit` to not terminate the program.)

Also, using asyncio, you must always propagate a cancellation.